### PR TITLE
chore: add snapshot check to git pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 forge fmt --check
+npm run snapshot:check


### PR DESCRIPTION
It's annoying to forget to update the snapshot when changes have been made to the tests.