### PR TITLE
ci(release): removing bytecode from npm package

### DIFF
--- a/script/exportAbi.ts
+++ b/script/exportAbi.ts
@@ -4,7 +4,6 @@ import { basename } from "path";
 import { Command } from "commander";
 
 const ABI_EXPORT_PATH = "./dist/abi";
-const BYTECODE_EXPORT_PATH = "./dist/bytecode";
 
 const program = new Command();
 
@@ -31,10 +30,6 @@ if (existsSync(ABI_EXPORT_PATH))
   rmSync(ABI_EXPORT_PATH, { recursive: true, force: true });
 mkdirSync(ABI_EXPORT_PATH, { recursive: true });
 
-if (existsSync(BYTECODE_EXPORT_PATH))
-  rmSync(BYTECODE_EXPORT_PATH, { recursive: true, force: true });
-mkdirSync(BYTECODE_EXPORT_PATH, { recursive: true });
-
 let indexContent = "";
 
 for (const name of solFiles) {
@@ -50,7 +45,6 @@ for (const name of solFiles) {
     )} as const;\n`;
 
     writeFileSync(`${ABI_EXPORT_PATH}/${name}.ts`, fileContent);
-    writeFileSync(`${BYTECODE_EXPORT_PATH}/${name}.bytecode`, bytes);
     indexContent += `export * from './${name}';\n`;
   } catch {
     // Could be normal, if a solidity file does not contain a contract (only an interface)


### PR DESCRIPTION
Bytecode export removed since it's no longer needed in the npm package