### PR TITLE
ci(release): removing private from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "git@github.com:Blockchain-RA2-Tech/usdn-contracts.git",
   "author": "RA2 Tech",
   "license": "BUSL-1.1",
-  "private": true,
   "scripts": {
     "prepare": "husky install",
     "snapshot": "FOUNDRY_PROFILE=ci forge snapshot --no-match-test FFI",


### PR DESCRIPTION
Removing `"private": true` from package.json to allow the package to be published