### PR TITLE
ci(release): slight change to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@usdn/contracts",
+  "name": "@usdn/usdn-contracts",
   "version": "0.1.2",
   "description": "Contracts for the USDN token and derivatives protocol",
   "repository": "git@github.com:Blockchain-RA2-Tech/usdn-contracts.git",


### PR DESCRIPTION
- Setting package name to `@usdn/usdn-contracts` for more clarity and to re-trigger package publishing