### PR TITLE
chore: harmonize solidity version across source files

### DIFF
--- a/src/OracleMiddleware/WstEthOracleMiddleware.sol
+++ b/src/OracleMiddleware/WstEthOracleMiddleware.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import { IWstETH } from "src/interfaces/IWstETH.sol";
 import { PriceInfo } from "src/interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";

--- a/src/OracleMiddleware/mock/MockLiquidationRewardsManager.sol
+++ b/src/OracleMiddleware/mock/MockLiquidationRewardsManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import { ChainlinkPriceInfo } from "src/interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
 import { IWstETH } from "src/interfaces/IWstETH.sol";

--- a/src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol
+++ b/src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import { PriceInfo } from "src/interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
 import { ProtocolAction } from "src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";

--- a/src/OracleMiddleware/oracles/ChainlinkOracle.sol
+++ b/src/OracleMiddleware/oracles/ChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/src/OracleMiddleware/oracles/PythOracle.sol
+++ b/src/OracleMiddleware/oracles/PythOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 import { IPyth } from "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import { PythStructs } from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";

--- a/src/utils/InitializableReentrancyGuard.sol
+++ b/src/utils/InitializableReentrancyGuard.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Based on the OpenZeppelin implementation
 
-pragma solidity ^0.8.20;
+pragma solidity 0.8.20;
 
 /**
  * @title InitializableReentrancyGuard


### PR DESCRIPTION
As discussed, the solidity version should be fixed in files, except libraries.