### PR TITLE
test(usdn): improve invariant testing

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ solc_version = "0.8.20"
 optimizer = true
 optimizer_runs = 20_000
 libs = ["node_modules", "lib"]
+invariant = { fail_on_revert = true }
 
 # -------------------------------- Remappings -------------------------------- #
 

--- a/test/unit/USDN/utils/Handler.sol
+++ b/test/unit/USDN/utils/Handler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
-import { console, Test } from "forge-std/Test.sol";
+import { console2, Test } from "forge-std/Test.sol";
 
 import { Usdn } from "src/Usdn.sol";
 
@@ -41,7 +41,7 @@ contract UsdnHandler is Usdn, Test {
     /* ------------------ Functions used for invariant testing ------------------ */
 
     modifier useActor(uint256 actorIndexSeed) {
-        console.log("bound actor ID");
+        console2.log("bound actor ID");
         _currentActor = actors[bound(actorIndexSeed, 0, actors.length - 1)];
         vm.startPrank(_currentActor);
         _;
@@ -52,18 +52,18 @@ contract UsdnHandler is Usdn, Test {
         if (_divisor == MIN_DIVISOR) {
             return;
         }
-        console.log("bound divisor");
+        console2.log("bound divisor");
         newDivisor = bound(newDivisor, MIN_DIVISOR, _divisor - 1);
         emit DivisorAdjusted(_divisor, newDivisor);
         _divisor = newDivisor;
     }
 
     function mintTest(uint256 value, uint256 actorIndexSeed) external useActor(actorIndexSeed) {
-        if (totalSupply() == maxTokens()) {
+        if (totalSupply() >= maxTokens() - 1) {
             return;
         }
-        console.log("bound mint value");
-        value = bound(value, 1, maxTokens() - totalSupply());
+        console2.log("bound mint value");
+        value = bound(value, 1, maxTokens() - totalSupply() - 1);
         uint256 valueShares = value * _divisor;
         totalSharesSum += valueShares;
         shares[_currentActor] += valueShares;
@@ -74,21 +74,24 @@ contract UsdnHandler is Usdn, Test {
         if (balanceOf(_currentActor) == 0) {
             return;
         }
-        console.log("bound burn value");
+        console2.log("bound burn value");
         value = bound(value, 1, balanceOf(_currentActor));
         uint256 valueShares = value * _divisor;
+        if (valueShares > shares[_currentActor]) {
+            valueShares = shares[_currentActor];
+        }
         totalSharesSum -= valueShares;
         shares[_currentActor] -= valueShares;
         _burn(_currentActor, value);
     }
 
     function transferTest(uint256 actorTo, uint256 value, uint256 actorIndexSeed) external useActor(actorIndexSeed) {
-        console.log("bound 'to' actor ID");
+        console2.log("bound 'to' actor ID");
         address to = actors[bound(actorTo, 0, actors.length - 1)];
         if (balanceOf(_currentActor) == 0) {
             return;
         }
-        console.log("bound transfer value");
+        console2.log("bound transfer value");
         value = bound(value, 1, balanceOf(_currentActor));
         uint256 valueShares = value * _divisor;
         if (valueShares > shares[_currentActor]) {


### PR DESCRIPTION
This PR adjusts the invariant testing parameters so that we get a failure if an action reverts.

This allowed to identify a slight improvement potential for the handler, which now can't mint tokens that would cause an overflow of the total shares.

Likewise, when burning, we perform the same check internally to the handler as we do in the real usdn contract, that is we avoid that we try to burn more shares than the balance of the user.