### PR TITLE
refactor(deploy): refactor the deployment script to avoid stack too deep error

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,14 +6,14 @@ import { Script } from "forge-std/Script.sol";
 import { Sdex } from "test/utils/Sdex.sol";
 import { WstETH } from "test/utils/WstEth.sol";
 
-import { LiquidationRewardsManager } from "src/OracleMiddleware/LiquidationRewardsManager.sol";
-import { IWstETH } from "src/interfaces/IWstETH.sol";
-import { Usdn } from "src/Usdn.sol";
-import { UsdnProtocol } from "src/UsdnProtocol/UsdnProtocol.sol";
 import { ProtocolAction } from "src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
-import { WstEthOracleMiddleware } from "src/OracleMiddleware/WstEthOracleMiddleware.sol";
-import { MockWstEthOracleMiddleware } from "src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol";
+import { IWstETH } from "src/interfaces/IWstETH.sol";
 import { MockLiquidationRewardsManager } from "src/OracleMiddleware/mock/MockLiquidationRewardsManager.sol";
+import { MockWstEthOracleMiddleware } from "src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol";
+import { LiquidationRewardsManager } from "src/OracleMiddleware/LiquidationRewardsManager.sol";
+import { WstEthOracleMiddleware } from "src/OracleMiddleware/WstEthOracleMiddleware.sol";
+import { UsdnProtocol } from "src/UsdnProtocol/UsdnProtocol.sol";
+import { Usdn } from "src/Usdn.sol";
 
 contract Deploy is Script {
     /**


### PR DESCRIPTION
We are starting to get stack too deep errors in the deployment script, so I refactored by separating the deployment of the different contracts into internal functions.

Just adding scopes made the code harder to follow, and using a struct might be overkill right now (but is much easier to do now that everything is well separated).