### PR TITLE
ci: coverage action was fixed

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
         uses: hrishikesh-kadam/setup-lcov@v1
 
       - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@hotfix/artifacts2
+        uses: zgosalvez/github-actions-report-lcov@v4
         with:
           coverage-files: lcov.info
           artifact-name: code-coverage-report


### PR DESCRIPTION
The version pin can be removed as the action author has fixed the bug.
https://github.com/zgosalvez/github-actions-report-lcov/issues/195