### PR TITLE
refactor(initiate-close)!: change the values sent in the InitiatedClosePosition event

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolActions.sol
+++ b/src/UsdnProtocol/UsdnProtocolActions.sol
@@ -951,7 +951,8 @@ abstract contract UsdnProtocolActions is IUsdnProtocolActions, UsdnProtocolLong 
             posId.tick,
             posId.tickVersion,
             posId.index,
-            pos.amount - amountToClose,
+            pos.amount,
+            amountToClose,
             pos.totalExpo - totalExpoToClose
         );
     }

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolEvents.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolEvents.sol
@@ -104,8 +104,9 @@ interface IUsdnProtocolEvents {
      * @param tick The tick containing the position.
      * @param tickVersion The tick version.
      * @param index The index of the position inside the tick array.
-     * @param amountRemaining The amount of collateral remaining in the position.
-     * If the entirety of the position is being closed, this value is zero.
+     * @param originalAmount The amount of collateral originally on the position.
+     * @param amountToClose The amount of collateral to close from the position.
+     * If the entirety of the position is being closed, this value equals originalAmount.
      * @param totalExpoRemaining The total expo remaining in the position.
      * If the entirety of the position is being closed, this value is zero.
      */
@@ -114,7 +115,8 @@ interface IUsdnProtocolEvents {
         int24 tick,
         uint256 tickVersion,
         uint256 index,
-        uint128 amountRemaining,
+        uint128 originalAmount,
+        uint128 amountToClose,
         uint128 totalExpoRemaining
     );
 

--- a/test/unit/UsdnProtocol/Actions/InititateClosePosition.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InititateClosePosition.t.sol
@@ -192,7 +192,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         bytes memory priceData = abi.encode(params.initialPrice);
 
         vm.expectEmit();
-        emit InitiatedClosePosition(address(this), tick, tickVersion, index, 0, 0);
+        emit InitiatedClosePosition(address(this), tick, tickVersion, index, positionAmount, positionAmount, 0);
         protocol.initiateClosePosition(tick, tickVersion, index, positionAmount, priceData, EMPTY_PREVIOUS_DATA);
     }
 
@@ -303,7 +303,8 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
             tick,
             tickVersion,
             index,
-            posBefore.amount - amountToClose,
+            posBefore.amount,
+            amountToClose,
             posBefore.totalExpo - totalExpoToClose
         );
         protocol.i_initiateClosePosition(


### PR DESCRIPTION
BREAKING CHANGE: The event now contains the original amount in the position and the amount to be subtracted from it