### PR TITLE
build(husky): remove the deprecated (since v9.0.1) `husky install` command in favor of `husky`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "RA2 Tech",
   "license": "BUSL-1.1",
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "snapshot": "FOUNDRY_PROFILE=ci forge clean && FOUNDRY_PROFILE=ci forge snapshot --no-match-test \"(FFI|Fork|Fuzz)\" --no-match-contract Fork --offline",
     "snapshot:check": "FOUNDRY_PROFILE=ci forge build && FOUNDRY_PROFILE=ci forge snapshot --no-match-test \"(FFI|Fork|Fuzz)\" --no-match-contract Fork --check --offline",
     "coverage": "FOUNDRY_PROFILE=ci forge coverage --report lcov --no-match-test \"(FFI|Fork|Fuzz|invariant)\"",


### PR DESCRIPTION
`husky install` is deprecated, we should now just call `husky` in the `prepare` npm script: https://github.com/typicode/husky/releases/tag/v9.0.1