### PR TITLE
Feature/adapt the protocol with to parameter

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolCore.sol
+++ b/src/UsdnProtocol/UsdnProtocolCore.sol
@@ -136,7 +136,7 @@ abstract contract UsdnProtocolCore is IUsdnProtocolCore, UsdnProtocolStorage {
             // If the currentUser is equal to the user of the pending action, then the pending action is not actionable
             // by this user (it will get validated automatically by their action). And so we need to return the next
             // item in the queue so that they can validate a third-party pending action (if any).
-            if (candidate.timestamp == 0 || candidate.user == currentUser) {
+            if (candidate.timestamp == 0 || candidate.validator == currentUser) {
                 rawIndices_[i] = rawIndex;
                 // try the next one
                 unchecked {

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
@@ -22,12 +22,14 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * @param currentPriceData The current price data
      * @param previousActionsData The data needed to validate actionable pending actions.
      * @param to The address that will receive the USDN tokens
+     * @param validator The address that will validate the deposit
      */
     function initiateDeposit(
         uint128 amount,
         bytes calldata currentPriceData,
         PreviousActionsData calldata previousActionsData,
-        address to
+        address to,
+        address validator
     ) external payable;
 
     /**
@@ -39,12 +41,12 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * The timestamp corresponding to the price data is calculated by adding the mandatory `validationDelay`
      * (from the oracle middleware) to the timestamp of the initiate action.
      * The security deposit will be returned to the sender.
-     * @param to The address register in the deposit action
+     * @param validator The address register in the deposit action
      * @param depositPriceData The price data corresponding to the sender's pending deposit action.
      * @param previousActionsData The data needed to validate actionable pending actions.
      */
     function validateDeposit(
-        address to,
+        address validator,
         bytes calldata depositPriceData,
         PreviousActionsData calldata previousActionsData
     ) external payable;
@@ -61,12 +63,14 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * @param currentPriceData The current price data
      * @param previousActionsData The data needed to validate actionable pending actions.
      * @param to The address that will receive the assets
+     * @param validator The address that will validate the withdrawal
      */
     function initiateWithdrawal(
         uint152 usdnShares,
         bytes calldata currentPriceData,
         PreviousActionsData calldata previousActionsData,
-        address to
+        address to,
+        address validator
     ) external payable;
 
     /**
@@ -78,12 +82,12 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * The timestamp corresponding to the price data is calculated by adding the mandatory `validationDelay`
      * (from the oracle middleware) to the timestamp of the initiate action.
      * The security deposit will be returned to the sender.
-     * @param to The address register in the withdrawal action
+     * @param validator The address register in the withdrawal action
      * @param withdrawalPriceData The price data corresponding to the sender's pending withdrawal action.
      * @param previousActionsData The data needed to validate actionable pending actions.
      */
     function validateWithdrawal(
-        address to,
+        address validator,
         bytes calldata withdrawalPriceData,
         PreviousActionsData calldata previousActionsData
     ) external payable;
@@ -103,6 +107,7 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * pending validation)
      * @param previousActionsData The data needed to validate actionable pending actions.
      * @param to The address that will be the owner of the position
+     * @param validator The address that will validate the open position
      * @return tick_ The tick containing the new position
      * @return tickVersion_ The tick version
      * @return index_ The index of the new position inside the tick array
@@ -112,7 +117,8 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
         uint128 desiredLiqPrice,
         bytes calldata currentPriceData,
         PreviousActionsData calldata previousActionsData,
-        address to
+        address to,
+        address validator
     ) external payable returns (int24 tick_, uint256 tickVersion_, uint256 index_);
 
     /**
@@ -127,12 +133,12 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * It is also possible for this operation to change the tick, tickVersion and index of the position, in which case
      * we emit the `LiquidationPriceUpdated` event.
      * The security deposit will be returned to the sender.
-     * @param to The address register in the open position action
+     * @param validator The address register in the open position action
      * @param openPriceData The price data corresponding to the sender's pending open position action.
      * @param previousActionsData The data needed to validate actionable pending actions.
      */
     function validateOpenPosition(
-        address to,
+        address validator,
         bytes calldata openPriceData,
         PreviousActionsData calldata previousActionsData
     ) external payable;
@@ -157,6 +163,7 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * @param currentPriceData The current price data
      * @param previousActionsData The data needed to validate actionable pending actions.
      * @param to The address that will receive the assets
+     * @param validator The address that will validate the close position
      */
     function initiateClosePosition(
         int24 tick,
@@ -165,7 +172,8 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
         uint128 amountToClose,
         bytes calldata currentPriceData,
         PreviousActionsData calldata previousActionsData,
-        address to
+        address to,
+        address validator
     ) external payable;
 
     /**
@@ -178,12 +186,12 @@ interface IUsdnProtocolActions is IUsdnProtocolLong {
      * (from the oracle middleware) to the timestamp of the initiate action.
      * This operation calculates the final exit price and profit of the long position and performs the payout.
      * The security deposit will be returned to the sender.
-     * @param to The address register in the close position action
+     * @param validator The address register in the close position action
      * @param closePriceData The price data corresponding to the sender's pending close position action.
      * @param previousActionsData The data needed to validate actionable pending actions.
      */
     function validateClosePosition(
-        address to,
+        address validator,
         bytes calldata closePriceData,
         PreviousActionsData calldata previousActionsData
     ) external payable;

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol
@@ -48,8 +48,8 @@ enum ProtocolAction {
  * @notice A pending action in the queue.
  * @param action The action type (Validate...).
  * @param timestamp The timestamp of the initiate action.
- * @param user The user address.
  * @param to The to address.
+ * @param validator The validator address.
  * @param securityDepositValue The security deposit of the pending action.
  * @param var1 See `DepositPendingAction`, `WithdrawalPendingAction` and `LongPendingAction`.
  * @param amount The amount of the pending action.
@@ -62,8 +62,8 @@ enum ProtocolAction {
 struct PendingAction {
     ProtocolAction action; // 1 byte
     uint40 timestamp; // 5 bytes
-    address user; // 20 bytes
     address to; // 20 bytes
+    address validator; // 20 bytes
     uint24 securityDepositValue; // 3 bytes
     int24 var1; // 3 bytes
     uint128 amount; // 16 bytes
@@ -78,8 +78,8 @@ struct PendingAction {
  * @notice A pending action in the queue for a vault deposit.
  * @param action The action type (`ValidateDeposit`).
  * @param timestamp The timestamp of the initiate action.
- * @param user The user address.
  * @param to The to address.
+ * @param validator The validator address.
  * @param securityDepositValue The security deposit of the pending action.
  * @param _unused Unused field to align the struct to `PendingAction`.
  * @param amount The amount of assets of the pending deposit.
@@ -92,8 +92,8 @@ struct PendingAction {
 struct DepositPendingAction {
     ProtocolAction action; // 1 byte
     uint40 timestamp; // 5 bytes
-    address user; // 20 bytes
     address to; // 20 bytes
+    address validator; // 20 bytes
     uint24 securityDepositValue; // 3 bytes
     int24 _unused; // 3 bytes
     uint128 amount; // 16 bytes
@@ -108,8 +108,8 @@ struct DepositPendingAction {
  * @notice A pending action in the queue for a vault withdrawal.
  * @param action The action type (`ValidateWithdrawal`).
  * @param timestamp The timestamp of the initiate action.
- * @param user The user address.
  * @param to The to address.
+ * @param validator The validator address.
  * @param securityDepositValue The security deposit of the pending action.
  * @param sharesLSB 3 least significant bytes of the withdrawal shares amount (uint152).
  * @param sharesMSB 16 most significant bytes of the withdrawal shares amount (uint152).
@@ -122,8 +122,8 @@ struct DepositPendingAction {
 struct WithdrawalPendingAction {
     ProtocolAction action; // 1 byte
     uint40 timestamp; // 5 bytes
-    address user; // 20 bytes
     address to; // 20 bytes
+    address validator; // 20 bytes
     uint24 securityDepositValue; // 3 bytes
     uint24 sharesLSB; // 3 bytes
     uint128 sharesMSB; // 16 bytes
@@ -138,8 +138,8 @@ struct WithdrawalPendingAction {
  * @notice A pending action in the queue for a long position.
  * @param action The action type (`ValidateOpenPosition` or `ValidateClosePosition`).
  * @param timestamp The timestamp of the initiate action.
- * @param user The user address.
  * @param to The to address.
+ * @param validator The validator address.
  * @param securityDepositValue The security deposit of the pending action.
  * @param tick The tick of the position.
  * @param closeAmount The amount of the pending action (only used when closing a position).
@@ -154,8 +154,8 @@ struct WithdrawalPendingAction {
 struct LongPendingAction {
     ProtocolAction action; // 1 byte
     uint40 timestamp; // 5 bytes
-    address user; // 20 bytes
     address to; // 20 bytes
+    address validator; // 20 bytes
     uint24 securityDepositValue; // 3 bytes
     int24 tick; // 3 bytes
     uint128 closeAmount; // 16 bytes

--- a/test/integration/UsdnProtocol/HighImbalance.t.sol
+++ b/test/integration/UsdnProtocol/HighImbalance.t.sol
@@ -48,7 +48,7 @@ contract UsdnProtocolHighImbalanceTest is UsdnProtocolBaseIntegrationFixture {
             + protocol.getSecurityDepositValue();
 
         protocol.initiateOpenPosition{ value: messageValue }(
-            3 ether, 2563 ether, "", EMPTY_PREVIOUS_DATA, address(this)
+            3 ether, 2563 ether, "", EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         vm.warp(1_708_090_246);
@@ -64,7 +64,7 @@ contract UsdnProtocolHighImbalanceTest is UsdnProtocolBaseIntegrationFixture {
         mockChainlinkOnChain.setLastPrice(3290e8);
 
         protocol.initiateOpenPosition{ value: messageValue }(
-            3.01 ether, 2674 ether, "", EMPTY_PREVIOUS_DATA, address(this)
+            3.01 ether, 2674 ether, "", EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         vm.warp(1_708_090_438);
@@ -87,7 +87,7 @@ contract UsdnProtocolHighImbalanceTest is UsdnProtocolBaseIntegrationFixture {
         wstETH.approve(address(protocol), type(uint256).max);
 
         protocol.initiateOpenPosition{ value: messageValue }(
-            4.0001 ether, 1684 ether, "", EMPTY_PREVIOUS_DATA, address(this)
+            4.0001 ether, 1684 ether, "", EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         vm.stopPrank();
 

--- a/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
+++ b/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
@@ -96,15 +96,15 @@ contract ForkUsdnProtocolLiquidationGasUsageTest is UsdnProtocolBaseIntegrationF
 
         vm.prank(USER_1);
         protocol.initiateOpenPosition{ value: securityDepositValue }(
-            1 ether, pythPriceNormalized + 150e18, hex"beef", EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, pythPriceNormalized + 150e18, hex"beef", EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         vm.prank(USER_2);
         protocol.initiateOpenPosition{ value: securityDepositValue }(
-            1 ether, pythPriceNormalized + 100e18, hex"beef", EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, pythPriceNormalized + 100e18, hex"beef", EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         vm.prank(USER_3);
         protocol.initiateOpenPosition{ value: securityDepositValue }(
-            1 ether, pythPriceNormalized + 50e18, hex"beef", EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, pythPriceNormalized + 50e18, hex"beef", EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
         vm.prank(USER_1);

--- a/test/integration/UsdnProtocol/ValidateTwoPos.t.sol
+++ b/test/integration/UsdnProtocol/ValidateTwoPos.t.sol
@@ -33,7 +33,9 @@ contract ForkUsdnProtocolValidateTwoPosTest is UsdnProtocolBaseIntegrationFixtur
         uint256 ethValue = oracleMiddleware.validationCost("", ProtocolAction.InitiateOpenPosition)
             + protocol.getSecurityDepositValue();
 
-        protocol.initiateOpenPosition{ value: ethValue }(2.5 ether, 1000 ether, "", EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateOpenPosition{ value: ethValue }(
+            2.5 ether, 1000 ether, "", EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         uint256 ts1 = block.timestamp;
         vm.stopPrank();
         skip(30);
@@ -41,7 +43,9 @@ contract ForkUsdnProtocolValidateTwoPosTest is UsdnProtocolBaseIntegrationFixtur
         (success,) = address(wstETH).call{ value: 10 ether }("");
         require(success, "USER_2 wstETH mint failed");
         wstETH.approve(address(protocol), type(uint256).max);
-        protocol.initiateOpenPosition{ value: ethValue }(2.5 ether, 1000 ether, "", EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateOpenPosition{ value: ethValue }(
+            2.5 ether, 1000 ether, "", EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         uint256 ts2 = block.timestamp;
         vm.stopPrank();
 

--- a/test/unit/DoubleEndedQueue/Populated.t.sol
+++ b/test/unit/DoubleEndedQueue/Populated.t.sol
@@ -291,7 +291,7 @@ contract TestDequePopulated is DequeFixture {
         (PendingAction memory clearedAction,) = handler.at(1);
         assertTrue(clearedAction.action == ProtocolAction.None);
         assertEq(clearedAction.timestamp, 0);
-        assertEq(clearedAction.user, address(0));
+        assertEq(clearedAction.validator, address(0));
         assertEq(clearedAction.var1, 0);
         assertEq(clearedAction.amount, 0);
     }

--- a/test/unit/DoubleEndedQueue/utils/Fixtures.sol
+++ b/test/unit/DoubleEndedQueue/utils/Fixtures.sol
@@ -26,7 +26,7 @@ contract DequeFixture is BaseFixture {
     function _assertActionsEqual(PendingAction memory a, PendingAction memory b, string memory err) internal {
         assertTrue(a.action == b.action, string.concat(err, " - action type"));
         assertEq(a.timestamp, b.timestamp, string.concat(err, " - action timestamp"));
-        assertEq(a.user, b.user, string.concat(err, " - action user"));
+        assertEq(a.validator, b.validator, string.concat(err, " - action user"));
         assertEq(a.var1, b.var1, string.concat(err, " - action var1"));
         assertEq(a.amount, b.amount, string.concat(err, " - action amount"));
         assertEq(a.var2, b.var2, string.concat(err, " - action var2"));

--- a/test/unit/UsdnProtocol/Actions/ClosePosition.fuzzing.t.sol
+++ b/test/unit/UsdnProtocol/Actions/ClosePosition.fuzzing.t.sol
@@ -61,10 +61,17 @@ contract TestUsdnProtocolActionsClosePositionFuzzing is UsdnProtocolBaseFixture 
             amountClosed += amountToClose;
 
             protocol.initiateClosePosition(
-                tick, tickVersion, index, uint128(amountToClose), priceData, EMPTY_PREVIOUS_DATA, address(this)
+                tick,
+                tickVersion,
+                index,
+                uint128(amountToClose),
+                priceData,
+                EMPTY_PREVIOUS_DATA,
+                address(this),
+                address(this)
             );
             _waitDelay();
-            protocol.i_validateClosePosition(address(this), address(this), priceData);
+            protocol.i_validateClosePosition(address(this), priceData);
 
             (Position memory posAfter,) = protocol.getLongPosition(tick, tickVersion, index);
             assertEq(
@@ -87,10 +94,11 @@ contract TestUsdnProtocolActionsClosePositionFuzzing is UsdnProtocolBaseFixture 
                 uint128(amountToOpen - amountClosed),
                 priceData,
                 EMPTY_PREVIOUS_DATA,
+                address(this),
                 address(this)
             );
             _waitDelay();
-            protocol.i_validateClosePosition(address(this), address(this), priceData);
+            protocol.i_validateClosePosition(address(this), priceData);
         }
 
         (Position memory pos,) = protocol.getLongPosition(tick, tickVersion, index);

--- a/test/unit/UsdnProtocol/Actions/Deposit.t.sol
+++ b/test/unit/UsdnProtocol/Actions/Deposit.t.sol
@@ -69,7 +69,7 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         emit Transfer(address(this), deadAddress, expectedSdexBurnAmount); // SDEX transfer
         vm.expectEmit();
         emit InitiatedDeposit(address(this), to, depositAmount, block.timestamp);
-        protocol.initiateDeposit(depositAmount, currentPrice, EMPTY_PREVIOUS_DATA, to);
+        protocol.initiateDeposit(depositAmount, currentPrice, EMPTY_PREVIOUS_DATA, to, address(this));
 
         assertEq(wstETH.balanceOf(address(this)), INITIAL_WSTETH_BALANCE - depositAmount, "wstETH user balance");
         assertEq(
@@ -96,14 +96,14 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         PendingAction memory action = protocol.getUserPendingAction(to);
         assertTrue(action.action == ProtocolAction.ValidateDeposit, "action type");
         assertEq(action.timestamp, block.timestamp, "action timestamp");
-        assertEq(action.user, address(this), "action user");
+        assertEq(action.validator, address(this), "action validator");
         assertEq(action.to, to, "action to");
         assertEq(action.amount, depositAmount, "action amount");
 
         // the pending action should be actionable after the validation deadline
         skip(protocol.getValidationDeadline() + 1);
         (actions,) = protocol.getActionablePendingActions(address(0));
-        assertEq(actions[0].user, address(this), "pending action user");
+        assertEq(actions[0].validator, address(this), "pending action validator");
     }
 
     /**
@@ -114,7 +114,9 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
      */
     function test_RevertWhen_zeroAddressTo() public {
         vm.expectRevert(UsdnProtocolInvalidAddressTo.selector);
-        protocol.initiateDeposit(1 ether, abi.encode(uint128(2000 ether)), EMPTY_PREVIOUS_DATA, address(0));
+        protocol.initiateDeposit(
+            1 ether, abi.encode(uint128(2000 ether)), EMPTY_PREVIOUS_DATA, address(0), address(this)
+        );
     }
 
     /**
@@ -125,7 +127,7 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
     function test_RevertWhen_zeroAmount() public {
         bytes memory priceData = abi.encode(uint128(2000 ether));
         vm.expectRevert(UsdnProtocolZeroAmount.selector);
-        protocol.initiateDeposit(0, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(0, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this));
     }
 
     /**
@@ -149,7 +151,9 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         assertEq(usdnToMintEstimated, 0, "usdn minted");
 
         vm.expectRevert(UsdnProtocolDepositTooSmall.selector);
-        protocol.initiateDeposit(deposited, abi.encode(params.initialPrice), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(
+            deposited, abi.encode(params.initialPrice), EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
     }
 
     /**
@@ -179,7 +183,9 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         assertEq(sdexToBurn, 0, "sdex burned");
 
         vm.expectRevert(UsdnProtocolDepositTooSmall.selector);
-        protocol.initiateDeposit(deposited, abi.encode(params.initialPrice), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(
+            deposited, abi.encode(params.initialPrice), EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
     }
 
     /**
@@ -202,7 +208,9 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
             protocol.i_calcMintUsdn(deposited, protocol.getBalanceVault(), usdn.totalSupply(), params.initialPrice);
         assertGt(usdnToMintEstimated, 0, "usdn minted");
 
-        protocol.initiateDeposit(deposited, abi.encode(params.initialPrice), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(
+            deposited, abi.encode(params.initialPrice), EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
     }
 
     /**
@@ -257,7 +265,9 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         uint256 balanceBefore = address(this).balance;
         bytes memory currentPrice = abi.encode(uint128(2000 ether));
         uint256 validationCost = oracleMiddleware.validationCost(currentPrice, ProtocolAction.InitiateDeposit);
-        protocol.initiateDeposit{ value: 0.5 ether }(1 ether, currentPrice, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit{ value: 0.5 ether }(
+            1 ether, currentPrice, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         assertEq(address(this).balance, balanceBefore - validationCost, "user balance after refund");
     }
 
@@ -273,7 +283,9 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         bytes memory currentPrice = abi.encode(uint128(2000 ether));
         uint256 validationCost = oracleMiddleware.validationCost(currentPrice, ProtocolAction.InitiateDeposit);
         assertEq(validationCost, 1);
-        protocol.initiateDeposit{ value: validationCost }(1 ether, currentPrice, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit{ value: validationCost }(
+            1 ether, currentPrice, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         _waitDelay();
         // validate
@@ -307,7 +319,7 @@ contract TestUsdnProtocolDeposit is UsdnProtocolBaseFixture {
         uint256 initiateDepositTimestamp = block.timestamp;
         vm.expectEmit();
         emit InitiatedDeposit(address(this), to, depositAmount, initiateDepositTimestamp); // expected event
-        protocol.initiateDeposit(depositAmount, currentPrice, EMPTY_PREVIOUS_DATA, to);
+        protocol.initiateDeposit(depositAmount, currentPrice, EMPTY_PREVIOUS_DATA, to, address(this));
         uint256 vaultBalance = protocol.getBalanceVault(); // save for mint amount calculation in case price increases
 
         // wait the required delay between initiation and validation

--- a/test/unit/UsdnProtocol/Actions/InititateClosePosition.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InititateClosePosition.t.sol
@@ -66,6 +66,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         protocol.i_initiateClosePosition(
             address(this),
             address(this),
+            address(this),
             PositionId({ tick: tick, tickVersion: tickVersion, index: index }),
             amountToClose,
             priceData
@@ -81,6 +82,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         bytes memory priceData = abi.encode(params.initialPrice);
         vm.expectRevert(UsdnProtocolUnauthorized.selector);
         protocol.i_initiateClosePosition(
+            USER_1,
             USER_1,
             USER_1,
             PositionId({ tick: tick, tickVersion: tickVersion, index: index }),
@@ -99,7 +101,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         bytes memory priceData = abi.encode(params.initialPrice);
         vm.expectRevert(UsdnProtocolInvalidAddressTo.selector);
         protocol.i_initiateClosePosition(
-            USER_1, address(0), PositionId(tick, tickVersion, index), positionAmount, priceData
+            USER_1, address(0), USER_1, PositionId(tick, tickVersion, index), positionAmount, priceData
         );
     }
 
@@ -114,6 +116,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
 
         vm.expectRevert(abi.encodeWithSelector(UsdnProtocolAmountToCloseIsZero.selector));
         protocol.i_initiateClosePosition(
+            address(this),
             address(this),
             address(this),
             PositionId({ tick: tick, tickVersion: tickVersion, index: index }),
@@ -144,6 +147,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         protocol.i_initiateClosePosition(
             address(this),
             address(this),
+            address(this),
             PositionId({ tick: tick, tickVersion: tickVersion, index: index }),
             positionAmount / 2,
             priceData
@@ -166,7 +170,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         uint256 etherBalanceBefore = address(this).balance;
 
         protocol.initiateClosePosition{ value: 1 ether }(
-            tick, tickVersion, index, positionAmount, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, positionAmount, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         assertEq(
@@ -212,6 +216,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
             positionAmount,
             priceData,
             PreviousActionsData(previousData, rawIndices),
+            address(this),
             address(this)
         );
     }
@@ -230,7 +235,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
             address(this), address(this), tick, tickVersion, index, positionAmount, positionAmount, 0
         );
         protocol.initiateClosePosition(
-            tick, tickVersion, index, positionAmount, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, positionAmount, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 
@@ -366,6 +371,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         protocol.i_initiateClosePosition(
             address(this),
             to,
+            address(this),
             PositionId({ tick: tick, tickVersion: tickVersion, index: index }),
             amountToClose,
             abi.encode(params.initialPrice)
@@ -375,7 +381,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
         LongPendingAction memory action = protocol.i_toLongPendingAction(protocol.getUserPendingAction(to));
         assertTrue(action.action == ProtocolAction.ValidateClosePosition, "The action type is wrong");
         assertEq(action.timestamp, block.timestamp, "The block timestamp should be now");
-        assertEq(action.user, address(this), "The user should be the transaction sender");
+        assertEq(action.validator, address(this), "The validator should be the transaction sender");
         assertEq(action.to, to, "To is wrong");
         assertEq(action.tick, tick, "The position tick is wrong");
         assertEq(

--- a/test/unit/UsdnProtocol/Actions/Liquidation.t.sol
+++ b/test/unit/UsdnProtocol/Actions/Liquidation.t.sol
@@ -54,7 +54,9 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
         // Check that tick has been liquidated
         vm.expectEmit(true, true, false, false);
         emit IUsdnProtocolEvents.LiquidatedTick(tick, tickVersion, 0, 0, 0);
-        protocol.initiateDeposit(1 ether, abi.encode(effectivePriceForTick), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(
+            1 ether, abi.encode(effectivePriceForTick), EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
     }
 
     /**
@@ -133,6 +135,7 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
             uint128(usdn.balanceOf(address(this))),
             abi.encode(effectivePriceForTick),
             EMPTY_PREVIOUS_DATA,
+            address(this),
             address(this)
         );
     }
@@ -211,7 +214,12 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
         vm.expectEmit(true, true, false, false);
         emit IUsdnProtocolEvents.LiquidatedTick(tick, tickVersion, 0, 0, 0);
         protocol.initiateOpenPosition(
-            1 ether, desiredLiqPrice - 200 ether, abi.encode(effectivePriceForTick), EMPTY_PREVIOUS_DATA, address(this)
+            1 ether,
+            desiredLiqPrice - 200 ether,
+            abi.encode(effectivePriceForTick),
+            EMPTY_PREVIOUS_DATA,
+            address(this),
+            address(this)
         );
     }
 
@@ -314,6 +322,7 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
             1 ether,
             abi.encode(effectivePriceForTick),
             EMPTY_PREVIOUS_DATA,
+            address(this),
             address(this)
         );
     }
@@ -564,7 +573,7 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
         // create high risk position
         protocol.initiateOpenPosition{
             value: oracleMiddleware.validationCost(priceData, ProtocolAction.InitiateOpenPosition)
-        }(5 ether, 9 * currentPrice / 10, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        }(5 ether, 9 * currentPrice / 10, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this));
         _waitDelay();
         protocol.validateOpenPosition{
             value: oracleMiddleware.validationCost(priceData, ProtocolAction.ValidateOpenPosition)

--- a/test/unit/UsdnProtocol/Actions/LiquidationRewardsUserActions.t.sol
+++ b/test/unit/UsdnProtocol/Actions/LiquidationRewardsUserActions.t.sol
@@ -71,7 +71,7 @@ contract TestLiquidationRewardsUserActions is UsdnProtocolBaseFixture {
     function test_liquidationRewards_initiateDeposit() public {
         vm.expectEmit();
         emit IUsdnProtocolEvents.LiquidatorRewarded(address(this), expectedLiquidatorRewards);
-        protocol.initiateDeposit(depositAmount, liquidationPriceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(depositAmount, liquidationPriceData, EMPTY_PREVIOUS_DATA, address(this), address(this));
 
         uint256 balanceSenderAfter = wstETH.balanceOf(address(this));
         uint256 balanceProtocolAfter = wstETH.balanceOf(address(protocol));
@@ -92,7 +92,7 @@ contract TestLiquidationRewardsUserActions is UsdnProtocolBaseFixture {
      * @custom:then The sender should receive the liquidation rewards
      */
     function test_liquidationRewards_validateDeposit() public {
-        protocol.initiateDeposit(depositAmount, initialPriceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(depositAmount, initialPriceData, EMPTY_PREVIOUS_DATA, address(this), address(this));
         _waitDelay();
 
         vm.expectEmit();
@@ -125,7 +125,11 @@ contract TestLiquidationRewardsUserActions is UsdnProtocolBaseFixture {
         vm.expectEmit();
         emit IUsdnProtocolEvents.LiquidatorRewarded(address(this), expectedLiquidatorRewards);
         protocol.initiateWithdrawal(
-            uint152(usdn.balanceOf(address(this))), liquidationPriceData, EMPTY_PREVIOUS_DATA, address(this)
+            uint152(usdn.balanceOf(address(this))),
+            liquidationPriceData,
+            EMPTY_PREVIOUS_DATA,
+            address(this),
+            address(this)
         );
 
         uint256 balanceSenderAfter = wstETH.balanceOf(address(this));
@@ -185,7 +189,7 @@ contract TestLiquidationRewardsUserActions is UsdnProtocolBaseFixture {
         vm.expectEmit();
         emit IUsdnProtocolEvents.LiquidatorRewarded(address(this), expectedLiquidatorRewards);
         protocol.initiateOpenPosition(
-            depositAmount, initialPrice / 2, liquidationPriceData, EMPTY_PREVIOUS_DATA, address(this)
+            depositAmount, initialPrice / 2, liquidationPriceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         uint256 balanceSenderAfter = wstETH.balanceOf(address(this));
@@ -209,7 +213,7 @@ contract TestLiquidationRewardsUserActions is UsdnProtocolBaseFixture {
      */
     function test_liquidationRewards_validateOpenPosition() public {
         protocol.initiateOpenPosition(
-            depositAmount, initialPrice / 2, initialPriceData, EMPTY_PREVIOUS_DATA, address(this)
+            depositAmount, initialPrice / 2, initialPriceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -252,7 +256,14 @@ contract TestLiquidationRewardsUserActions is UsdnProtocolBaseFixture {
         vm.expectEmit();
         emit IUsdnProtocolEvents.LiquidatorRewarded(address(this), expectedLiquidatorRewards);
         protocol.initiateClosePosition(
-            tick, tickVersion, index, depositAmount, liquidationPriceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick,
+            tickVersion,
+            index,
+            depositAmount,
+            liquidationPriceData,
+            EMPTY_PREVIOUS_DATA,
+            address(this),
+            address(this)
         );
 
         uint256 balanceSenderAfter = wstETH.balanceOf(address(this));

--- a/test/unit/UsdnProtocol/Actions/SecurityDeposit.t.sol
+++ b/test/unit/UsdnProtocol/Actions/SecurityDeposit.t.sol
@@ -47,7 +47,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -72,7 +72,9 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         // we initiate a 1 wei withdrawal
         usdn.approve(address(protocol), 1);
-        protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(1, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(
+            1, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         _waitDelay();
 
         assertSecurityDepositPaid(balanceSenderBefore, balanceProtocolBefore);
@@ -103,7 +105,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE }(
-            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -125,7 +127,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -221,7 +223,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
     function test_RevertWhen_secDec_lt_deposit() public {
         vm.expectRevert(UsdnProtocolSecurityDepositTooLow.selector);
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE - 1 }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 
@@ -235,7 +237,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.expectRevert(UsdnProtocolSecurityDepositTooLow.selector);
         protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE - 1 }(
-            1, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 
@@ -247,7 +249,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
     function test_RevertWhen_secDec_lt_openPosition() public {
         vm.expectRevert(UsdnProtocolSecurityDepositTooLow.selector);
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE - 1 }(
-            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 
@@ -269,7 +271,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.expectRevert(UsdnProtocolSecurityDepositTooLow.selector);
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE - 1 }(
-            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 
@@ -287,7 +289,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE + 100 }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -306,7 +308,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         usdn.approve(address(protocol), 1);
         protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE + 100 }(
-            1, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -323,7 +325,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE + 100 }(
-            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         assertSecurityDepositPaid(balanceSenderBefore, balanceProtocolBefore);
@@ -348,7 +350,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE + 100 }(
-            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -375,7 +377,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 usdnBalanceUser1Before = usdn.balanceOf(USER_1);
 
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -388,7 +390,9 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
             PreviousActionsData({ priceData: previousPriceData, rawIndices: rawIndices });
 
         vm.prank(USER_1);
-        protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(1 ether, priceData, previousActionsData, USER_1);
+        protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
+            1 ether, priceData, previousActionsData, USER_1, USER_1
+        );
         _waitDelay();
 
         assertRefundEthToUser1(balanceUser0Before, balanceUser1Before, balanceProtocolBefore);
@@ -419,13 +423,15 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 usdnBalanceUser1Before = usdn.balanceOf(USER_1);
 
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         assertSecurityDepositPaid(balanceUser0Before, balanceProtocolBefore);
 
         vm.prank(USER_1);
-        protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(1 ether, priceData, EMPTY_PREVIOUS_DATA, USER_1);
+        protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, USER_1, USER_1
+        );
         skip(protocol.getValidationDeadline() + 1);
 
         assertSecurityDepositPaidTwoUsers(balanceUser0Before, balanceUser1Before, balanceProtocolBefore);
@@ -468,7 +474,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         // we initiate a withdrawal for 1e18 shares of USDN
         usdn.approve(address(protocol), 2);
         protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(
-            1e18, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1e18, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -482,7 +488,9 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.startPrank(USER_1);
         usdn.approve(address(protocol), 2);
-        protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(1e18, priceData, previousActionsData, USER_1);
+        protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(
+            1e18, priceData, previousActionsData, USER_1, USER_1
+        );
         _waitDelay();
 
         assertRefundEthToUser1(balanceUser0Before, balanceUser1Before, balanceProtocolBefore);
@@ -519,7 +527,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         // we initiate a withdrawal for 1e18 sahres of USDN
         usdn.approve(address(protocol), 2);
         protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(
-            1e18, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1e18, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -527,7 +535,9 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.startPrank(USER_1);
         usdn.approve(address(protocol), 2);
-        protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(1e18, priceData, EMPTY_PREVIOUS_DATA, USER_1);
+        protocol.initiateWithdrawal{ value: SECURITY_DEPOSIT_VALUE }(
+            1e18, priceData, EMPTY_PREVIOUS_DATA, USER_1, USER_1
+        );
         skip(protocol.getValidationDeadline() + 1);
 
         assertSecurityDepositPaidTwoUsers(balanceUser0Before, balanceUser1Before, balanceProtocolBefore);
@@ -563,7 +573,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceUser1Before = USER_1.balance;
 
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -577,7 +587,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.prank(USER_1);
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, params.initialPrice / 2, priceData, previousActionsData, USER_1
+            1 ether, params.initialPrice / 2, priceData, previousActionsData, USER_1, USER_1
         );
         _waitDelay();
 
@@ -604,14 +614,14 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 balanceProtocolBefore = address(protocol).balance;
 
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
 
         assertSecurityDepositPaid(balanceUser0Before, balanceProtocolBefore);
 
         vm.prank(USER_1);
         protocol.initiateOpenPosition{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, USER_1
+            1 ether, params.initialPrice / 2, priceData, EMPTY_PREVIOUS_DATA, USER_1, USER_1
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -662,7 +672,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
 
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE }(
-            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -676,7 +686,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.prank(USER_1);
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE }(
-            tick1, tickVersion1, index1, 1 ether, priceData, previousActionsData, USER_1
+            tick1, tickVersion1, index1, 1 ether, priceData, previousActionsData, USER_1, USER_1
         );
         _waitDelay();
 
@@ -721,7 +731,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
 
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE }(
-            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -729,7 +739,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
         vm.startPrank(USER_1);
         protocol.initiateClosePosition{ value: SECURITY_DEPOSIT_VALUE }(
-            tick1, tickVersion1, index1, 1 ether, priceData, EMPTY_PREVIOUS_DATA, USER_1
+            tick1, tickVersion1, index1, 1 ether, priceData, EMPTY_PREVIOUS_DATA, USER_1, USER_1
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -765,7 +775,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 newSecurityDepositValue = SECURITY_DEPOSIT_VALUE / 2;
 
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 
@@ -793,7 +803,9 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
 
         usdn.approve(address(protocol), 1);
-        protocol.initiateWithdrawal{ value: newSecurityDepositValue }(1, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateWithdrawal{ value: newSecurityDepositValue }(
+            1, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         _waitDelay();
 
         assertEq(
@@ -840,7 +852,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         uint256 newSecurityDepositValue = SECURITY_DEPOSIT_VALUE / 2;
 
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         skip(protocol.getValidationDeadline() + 1);
 
@@ -861,7 +873,9 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
             PreviousActionsData({ priceData: previousPriceData, rawIndices: rawIndices });
 
         vm.prank(USER_1);
-        protocol.initiateDeposit{ value: newSecurityDepositValue }(1 ether, priceData, previousActionsData, USER_1);
+        protocol.initiateDeposit{ value: newSecurityDepositValue }(
+            1 ether, priceData, previousActionsData, USER_1, USER_1
+        );
         _waitDelay();
 
         assertEq(
@@ -912,7 +926,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         vm.expectEmit();
         emit StalePendingActionRemoved(address(this), tick, tickVersion, index);
         protocol.initiateDeposit{ value: SECURITY_DEPOSIT_VALUE }(
-            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
 

--- a/test/unit/UsdnProtocol/Actions/_ExecutePendingActionOrRevert.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ExecutePendingActionOrRevert.t.sol
@@ -84,7 +84,7 @@ contract TestUsdnProtocolActionsExecutePendingActionOrRevert is UsdnProtocolBase
 
         PendingAction memory pending;
         pending.action = ProtocolAction.InitiateDeposit;
-        pending.user = USER_1;
+        pending.validator = USER_1;
         pending.timestamp = uint40(block.timestamp - protocol.getValidationDeadline() - 1);
         uint128 rawIndex1 = protocol.queuePushFront(pending);
         assertEq(rawIndex1, type(uint128).max, "raw index 1");
@@ -99,7 +99,7 @@ contract TestUsdnProtocolActionsExecutePendingActionOrRevert is UsdnProtocolBase
 
         (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0));
         assertEq(actions.length, 1, "one pending action left");
-        assertEq(actions[0].user, address(this), "pending action user");
+        assertEq(actions[0].validator, address(this), "pending action validator");
     }
 
     /**
@@ -109,7 +109,7 @@ contract TestUsdnProtocolActionsExecutePendingActionOrRevert is UsdnProtocolBase
     function _addDummyPendingAction() internal returns (uint128 rawIndex_) {
         PendingAction memory pending;
         pending.action = ProtocolAction.InitiateDeposit;
-        pending.user = address(this);
+        pending.validator = address(this);
         pending.timestamp = uint40(block.timestamp - protocol.getValidationDeadline() - 1);
         protocol.i_addPendingAction(address(this), pending);
         (, rawIndex_) = protocol.i_getPendingAction(address(this));

--- a/test/unit/UsdnProtocol/Actions/_ImbalanceLimitClose.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ImbalanceLimitClose.t.sol
@@ -96,6 +96,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
             params.initialLong,
             abi.encode(params.initialPrice),
             data,
+            DEPLOYER,
             DEPLOYER
         );
 

--- a/test/unit/UsdnProtocol/Actions/_ImbalanceLimitDeposit.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ImbalanceLimitDeposit.t.sol
@@ -62,6 +62,7 @@ contract TestImbalanceLimitDeposit is UsdnProtocolBaseFixture {
             params.initialLong,
             abi.encode(params.initialPrice),
             data,
+            DEPLOYER,
             DEPLOYER
         );
 

--- a/test/unit/UsdnProtocol/Actions/_ImbalanceLimitOpen.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ImbalanceLimitOpen.t.sol
@@ -89,6 +89,7 @@ contract TestExpoLimitsOpen is UsdnProtocolBaseFixture {
             0.1 ether,
             abi.encode(params.initialPrice * 10_000),
             EMPTY_PREVIOUS_DATA,
+            address(this),
             address(this)
         );
         _waitDelay();

--- a/test/unit/UsdnProtocol/Actions/_ImbalanceLimitWithdrawal.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ImbalanceLimitWithdrawal.t.sol
@@ -59,6 +59,7 @@ contract TestExpoLimitsWithdrawal is UsdnProtocolBaseFixture {
             0.5 ether,
             abi.encode(params.initialPrice * 10_000),
             EMPTY_PREVIOUS_DATA,
+            address(this),
             address(this)
         );
         _waitDelay();

--- a/test/unit/UsdnProtocol/Actions/_RefundExcessEther.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_RefundExcessEther.t.sol
@@ -19,7 +19,7 @@ contract TestRefundExcessEther is UsdnProtocolBaseFixture {
      */
     function test_RevertWhen_refundExcessEther() public {
         vm.expectRevert(UsdnProtocolUnexpectedBalance.selector);
-        protocol.i_refundExcessEther(1, 0, 0);
+        protocol.i_refundExcessEther(1, 0, 0, address(this));
     }
 
     /**
@@ -31,6 +31,6 @@ contract TestRefundExcessEther is UsdnProtocolBaseFixture {
      */
     function test_RevertWhen_refundExcessEther_noReceive() public {
         vm.expectRevert(UsdnProtocolEtherRefundFailed.selector);
-        protocol.i_refundExcessEther{ value: 1 ether }(0, 1 ether, 0);
+        protocol.i_refundExcessEther{ value: 1 ether }(0, 1 ether, 0, address(this));
     }
 }

--- a/test/unit/UsdnProtocol/Long/Long.t.sol
+++ b/test/unit/UsdnProtocol/Long/Long.t.sol
@@ -163,11 +163,13 @@ contract TestUsdnProtocolLong is UsdnProtocolBaseFixture {
         protocol.setMinLongPosition(2001 ether);
 
         vm.expectRevert(abi.encodeWithSelector(UsdnProtocolLongPositionTooSmall.selector));
-        protocol.initiateOpenPosition(1 ether, 1000 ether, abi.encode(2000 ether), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateOpenPosition(
+            1 ether, 1000 ether, abi.encode(2000 ether), EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         vm.expectRevert(abi.encodeWithSelector(UsdnProtocolLongPositionTooSmall.selector));
         protocol.initiateOpenPosition(
-            2.0001 ether, 500 ether, abi.encode(1000 ether), EMPTY_PREVIOUS_DATA, address(this)
+            2.0001 ether, 500 ether, abi.encode(1000 ether), EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 

--- a/test/unit/UsdnProtocol/Pending.t.sol
+++ b/test/unit/UsdnProtocol/Pending.t.sol
@@ -42,7 +42,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         skip(protocol.getValidationDeadline() + 1);
         (actions, rawIndices) = protocol.getActionablePendingActions(address(0));
         assertEq(actions.length, 1, "actions length");
-        assertEq(actions[0].user, address(this), "action user");
+        assertEq(actions[0].validator, address(this), "action validator");
         assertEq(rawIndices[0], 0, "raw index");
     }
 
@@ -65,7 +65,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         // the pending action is actionable after the validation deadline
         skip(protocol.getValidationDeadline() + 1);
         (action, rawIndex) = protocol.i_getActionablePendingAction();
-        assertEq(action.user, address(this), "action user");
+        assertEq(action.validator, address(this), "action validator");
         assertEq(rawIndex, 0, "raw index");
     }
 
@@ -124,7 +124,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
 
         (PendingAction[] memory actions, uint128[] memory rawIndices) = protocol.getActionablePendingActions(address(0));
         assertEq(actions.length, 2, "actions length");
-        assertEq(actions[1].user, USER_3, "user");
+        assertEq(actions[1].validator, USER_3, "validator");
         assertEq(rawIndices[1], 2, "raw index");
     }
 
@@ -142,7 +142,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         skip(protocol.getValidationDeadline() + 1);
 
         (PendingAction memory action, uint128 rawIndex) = protocol.i_getActionablePendingAction();
-        assertTrue(action.user == USER_3, "user");
+        assertTrue(action.validator == USER_3, "validator");
         assertEq(rawIndex, 2, "raw index");
     }
 
@@ -165,7 +165,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
      */
     function test_internalGetActionablePendingActionEmpty() public {
         (PendingAction memory action, uint128 rawIndex) = protocol.i_getActionablePendingAction();
-        assertEq(action.user, address(0), "action user");
+        assertEq(action.validator, address(0), "action validator");
         assertEq(rawIndex, 0, "raw index");
     }
 
@@ -195,7 +195,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         skip(protocol.getValidationDeadline() + 1);
         (PendingAction[] memory actions, uint128[] memory rawIndices) = protocol.getActionablePendingActions(address(0));
         assertEq(actions.length, 1, "actions length");
-        assertEq(actions[0].user, address(this), "action user");
+        assertEq(actions[0].validator, address(this), "action validator");
         assertEq(rawIndices[0], 0, "action rawIndex");
         // but if the user himself calls the function, the action should not be returned
         (actions, rawIndices) = protocol.getActionablePendingActions(address(this));
@@ -283,9 +283,9 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         PreviousActionsData memory previousActionsData =
             PreviousActionsData({ priceData: previousPriceData, rawIndices: rawIndices });
         vm.prank(USER_3);
-        protocol.initiateDeposit(1 ether, abi.encode(2200 ether), previousActionsData, USER_3);
+        protocol.initiateDeposit(1 ether, abi.encode(2200 ether), previousActionsData, USER_3, USER_3);
         vm.prank(USER_4);
-        protocol.initiateDeposit(1 ether, abi.encode(2200 ether), previousActionsData, USER_4);
+        protocol.initiateDeposit(1 ether, abi.encode(2200 ether), previousActionsData, USER_4, USER_4);
 
         // They should have validated both pending actions
         (actions, rawIndices) = protocol.getActionablePendingActions(address(0));
@@ -308,8 +308,8 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         PendingAction memory action = PendingAction({
             action: ProtocolAction.ValidateDeposit,
             timestamp: uint40(block.timestamp),
-            user: address(this),
             to: address(this),
+            validator: address(this),
             securityDepositValue: 2424,
             var1: 0, // must be zero because unused
             amount: 42,
@@ -322,7 +322,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         DepositPendingAction memory depositAction = protocol.i_toDepositPendingAction(action);
         assertTrue(depositAction.action == action.action, "action action");
         assertEq(depositAction.timestamp, action.timestamp, "action timestamp");
-        assertEq(depositAction.user, action.user, "action user");
+        assertEq(depositAction.validator, action.validator, "action validator");
         assertEq(depositAction.securityDepositValue, action.securityDepositValue, "action security deposit value");
         assertEq(depositAction.amount, action.amount, "action amount");
         assertEq(depositAction.assetPrice, action.var2, "action price");
@@ -344,8 +344,8 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         PendingAction memory action = PendingAction({
             action: ProtocolAction.ValidateWithdrawal,
             timestamp: uint40(block.timestamp),
-            user: address(this),
             to: address(this),
+            validator: address(this),
             securityDepositValue: 2424,
             var1: 125,
             amount: 42,
@@ -358,7 +358,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         WithdrawalPendingAction memory withdrawalAction = protocol.i_toWithdrawalPendingAction(action);
         assertTrue(withdrawalAction.action == action.action, "action action");
         assertEq(withdrawalAction.timestamp, action.timestamp, "action timestamp");
-        assertEq(withdrawalAction.user, action.user, "action user");
+        assertEq(withdrawalAction.validator, action.validator, "action validator");
         assertEq(withdrawalAction.to, action.to, "action to");
         assertEq(withdrawalAction.securityDepositValue, action.securityDepositValue, "action security deposit value");
         assertEq(int24(withdrawalAction.sharesLSB), action.var1, "action shares LSB");
@@ -382,8 +382,8 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         PendingAction memory action = PendingAction({
             action: ProtocolAction.ValidateOpenPosition,
             timestamp: uint40(block.timestamp),
-            user: address(this),
             to: address(this),
+            validator: address(this),
             var1: 2398,
             amount: 42,
             securityDepositValue: 2424,
@@ -396,7 +396,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         LongPendingAction memory longAction = protocol.i_toLongPendingAction(action);
         assertTrue(longAction.action == action.action, "action action");
         assertEq(longAction.timestamp, action.timestamp, "action timestamp");
-        assertEq(longAction.user, action.user, "action user");
+        assertEq(longAction.validator, action.validator, "action validator");
         assertEq(longAction.to, action.to, "action to");
         assertEq(longAction.tick, action.var1, "action tick");
         assertEq(longAction.securityDepositValue, action.securityDepositValue, "action security deposit value");

--- a/test/unit/UsdnProtocol/PositionFees.t.sol
+++ b/test/unit/UsdnProtocol/PositionFees.t.sol
@@ -50,7 +50,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         vm.recordLogs();
 
         bytes memory priceData = abi.encode(2000 ether);
-        protocol.initiateOpenPosition(1 ether, desiredLiqPrice, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateOpenPosition(
+            1 ether, desiredLiqPrice, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         (, uint128 leverage,, uint256 price,,,) =
@@ -145,7 +147,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
 
         uint256 storageBalanceBefore = protocol.getBalanceLong();
 
-        protocol.initiateClosePosition(tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateClosePosition(
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         LongPendingAction memory action = protocol.i_toLongPendingAction(protocol.getUserPendingAction(address(this)));
 
@@ -192,7 +196,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
 
         uint256 balanceBefore = wstETH.balanceOf(address(this));
 
-        protocol.initiateClosePosition(tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateClosePosition(
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         LongPendingAction memory action = protocol.i_toLongPendingAction(protocol.getUserPendingAction(address(this)));
 
@@ -316,7 +322,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         uint256 mintedUsdn = usdnBalanceAfter - usdnBalanceBefore;
 
         usdn.approve(address(protocol), type(uint256).max);
-        protocol.initiateWithdrawal(uint128(mintedUsdn), currentPrice, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateWithdrawal(
+            uint128(mintedUsdn), currentPrice, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         _waitDelay();
         PendingAction memory action = protocol.getUserPendingAction(address(this));
         WithdrawalPendingAction memory withdraw = protocol.i_toWithdrawalPendingAction(action);
@@ -347,7 +355,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         uint256 mintedUsdn = usdnBalanceAfter - usdnBalanceBefore;
 
         usdn.approve(address(protocol), type(uint256).max);
-        protocol.initiateWithdrawal(uint128(mintedUsdn), currentPrice, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateWithdrawal(
+            uint128(mintedUsdn), currentPrice, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
         _waitDelay();
 
         usdnBalanceBefore = usdn.balanceOf(address(this));
@@ -430,7 +440,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         protocol.setPositionFeeBps(100); // 1% fees
 
         protocol.initiateWithdrawal(
-            uint128(usdn.balanceOf(address(this))), currentPrice, EMPTY_PREVIOUS_DATA, address(this)
+            uint128(usdn.balanceOf(address(this))), currentPrice, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
         protocol.validateWithdrawal(address(this), currentPrice, EMPTY_PREVIOUS_DATA);
@@ -442,7 +452,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         vm.revertTo(snapshotId);
 
         protocol.initiateWithdrawal(
-            uint128(usdn.balanceOf(address(this))), currentPrice, EMPTY_PREVIOUS_DATA, address(this)
+            uint128(usdn.balanceOf(address(this))), currentPrice, EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
         _waitDelay();
         protocol.validateWithdrawal(address(this), currentPrice, EMPTY_PREVIOUS_DATA);
@@ -554,7 +564,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
 
         skip(1 hours);
 
-        protocol.initiateClosePosition(tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateClosePosition(
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         LongPendingAction memory action = protocol.i_toLongPendingAction(protocol.getUserPendingAction(address(this)));
 
@@ -587,7 +599,9 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         );
         skip(1 hours);
 
-        protocol.initiateClosePosition(tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateClosePosition(
+            tick, tickVersion, index, 1 ether, priceData, EMPTY_PREVIOUS_DATA, address(this), address(this)
+        );
 
         action = protocol.i_toLongPendingAction(protocol.getUserPendingAction(address(this)));
 

--- a/test/unit/UsdnProtocol/Rebase.t.sol
+++ b/test/unit/UsdnProtocol/Rebase.t.sol
@@ -124,7 +124,7 @@ contract TestUsdnProtocolRebase is UsdnProtocolBaseFixture, IUsdnEvents {
         // rebase
         vm.expectEmit(false, false, false, false);
         emit Rebase(0, 0);
-        protocol.initiateDeposit(1 ether, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateDeposit(1 ether, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this), address(this));
     }
 
     /**
@@ -170,7 +170,7 @@ contract TestUsdnProtocolRebase is UsdnProtocolBaseFixture, IUsdnEvents {
         // rebase
         vm.expectEmit(false, false, false, false);
         emit Rebase(0, 0);
-        protocol.initiateWithdrawal(100 ether, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this));
+        protocol.initiateWithdrawal(100 ether, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this), address(this));
     }
 
     /**
@@ -216,7 +216,7 @@ contract TestUsdnProtocolRebase is UsdnProtocolBaseFixture, IUsdnEvents {
         vm.expectEmit(false, false, false, false);
         emit Rebase(0, 0);
         protocol.initiateOpenPosition(
-            1 ether, params.initialPrice / 2, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this)
+            1 ether, params.initialPrice / 2, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 
@@ -280,7 +280,7 @@ contract TestUsdnProtocolRebase is UsdnProtocolBaseFixture, IUsdnEvents {
         vm.expectEmit(false, false, false, false);
         emit Rebase(0, 0);
         protocol.initiateClosePosition(
-            tick, tickVersion, index, 1 ether, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this)
+            tick, tickVersion, index, 1 ether, abi.encode(newPrice), EMPTY_PREVIOUS_DATA, address(this), address(this)
         );
     }
 

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -222,7 +222,9 @@ contract UsdnProtocolBaseFixture is BaseFixture, IUsdnProtocolErrors, IEvents, I
         wstETH.mintAndApprove(user, positionSize, address(protocol), positionSize);
         bytes memory priceData = abi.encode(price);
 
-        protocol.initiateDeposit{ value: securityDepositValue }(positionSize, priceData, EMPTY_PREVIOUS_DATA, user);
+        protocol.initiateDeposit{ value: securityDepositValue }(
+            positionSize, priceData, EMPTY_PREVIOUS_DATA, user, user
+        );
         _waitDelay();
         if (untilAction == ProtocolAction.InitiateDeposit) return;
 
@@ -233,7 +235,7 @@ contract UsdnProtocolBaseFixture is BaseFixture, IUsdnProtocolErrors, IEvents, I
         uint256 balanceOf = usdn.balanceOf(user);
         usdn.approve(address(protocol), balanceOf);
         protocol.initiateWithdrawal{ value: securityDepositValue }(
-            uint128(balanceOf), priceData, EMPTY_PREVIOUS_DATA, user
+            uint128(balanceOf), priceData, EMPTY_PREVIOUS_DATA, user, user
         );
         _waitDelay();
 
@@ -262,7 +264,12 @@ contract UsdnProtocolBaseFixture is BaseFixture, IUsdnProtocolErrors, IEvents, I
         bytes memory priceData = abi.encode(openParams.price);
 
         (tick_, tickVersion_, index_) = protocol.initiateOpenPosition{ value: securityDepositValue }(
-            openParams.positionSize, openParams.desiredLiqPrice, priceData, EMPTY_PREVIOUS_DATA, openParams.user
+            openParams.positionSize,
+            openParams.desiredLiqPrice,
+            priceData,
+            EMPTY_PREVIOUS_DATA,
+            openParams.user,
+            openParams.user
         );
         _waitDelay();
         if (openParams.untilAction == ProtocolAction.InitiateOpenPosition) return (tick_, tickVersion_, index_);
@@ -272,7 +279,14 @@ contract UsdnProtocolBaseFixture is BaseFixture, IUsdnProtocolErrors, IEvents, I
         if (openParams.untilAction == ProtocolAction.ValidateOpenPosition) return (tick_, tickVersion_, index_);
 
         protocol.initiateClosePosition{ value: securityDepositValue }(
-            tick_, tickVersion_, index_, openParams.positionSize, priceData, EMPTY_PREVIOUS_DATA, openParams.user
+            tick_,
+            tickVersion_,
+            index_,
+            openParams.positionSize,
+            priceData,
+            EMPTY_PREVIOUS_DATA,
+            openParams.user,
+            openParams.user
         );
         _waitDelay();
         if (openParams.untilAction == ProtocolAction.InitiateClosePosition) return (tick_, tickVersion_, index_);
@@ -315,7 +329,7 @@ contract UsdnProtocolBaseFixture is BaseFixture, IUsdnProtocolErrors, IEvents, I
     function _assertActionsEqual(PendingAction memory a, PendingAction memory b, string memory err) internal {
         assertTrue(a.action == b.action, string.concat(err, " - action type"));
         assertEq(a.timestamp, b.timestamp, string.concat(err, " - action timestamp"));
-        assertEq(a.user, b.user, string.concat(err, " - action user"));
+        assertEq(a.validator, b.validator, string.concat(err, " - action validator"));
         assertEq(a.var1, b.var1, string.concat(err, " - action var1"));
         assertEq(a.amount, b.amount, string.concat(err, " - action amount"));
         assertEq(a.var2, b.var2, string.concat(err, " - action var2"));

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -48,21 +48,22 @@ contract UsdnProtocolHandler is UsdnProtocol {
     /// @dev Push a pending item to the front of the pending actions queue
     function queuePushFront(PendingAction memory action) external returns (uint128 rawIndex_) {
         rawIndex_ = _pendingActionsQueue.pushFront(action);
-        _pendingActions[action.user] = uint256(rawIndex_) + 1;
+        _pendingActions[action.validator] = uint256(rawIndex_) + 1;
     }
 
     function i_initiateClosePosition(
         address user,
         address to,
+        address validator,
         PositionId memory posId,
         uint128 amountToClose,
         bytes calldata currentPriceData
     ) external returns (uint256 securityDepositValue_) {
-        return _initiateClosePosition(user, to, posId, amountToClose, currentPriceData);
+        return _initiateClosePosition(user, to, validator, posId, amountToClose, currentPriceData);
     }
 
-    function i_validateClosePosition(address user, address to, bytes calldata priceData) external {
-        _validateClosePosition(user, to, priceData);
+    function i_validateClosePosition(address validator, bytes calldata priceData) external {
+        _validateClosePosition(validator, priceData);
     }
 
     function i_removeAmountFromPosition(
@@ -313,11 +314,13 @@ contract UsdnProtocolHandler is UsdnProtocol {
         _executePendingActionOrRevert(data);
     }
 
-    function i_refundExcessEther(uint256 securityDepositValue, uint256 amountToRefund, uint256 balanceBefore)
-        external
-        payable
-    {
-        _refundExcessEther(securityDepositValue, amountToRefund, balanceBefore);
+    function i_refundExcessEther(
+        uint256 securityDepositValue,
+        uint256 amountToRefund,
+        uint256 balanceBefore,
+        address to
+    ) external payable {
+        _refundExcessEther(securityDepositValue, amountToRefund, balanceBefore, to);
     }
 
     function i_mergeWithdrawalAmountParts(uint24 sharesLSB, uint128 sharesMSB) external pure returns (uint256) {


### PR DESCRIPTION
Previously, when the router opened a position, this position was saved in its data space pending action. This meant that the router could only initiate one pending action.


Now, when we specify a “to”, it's this “to” that is saved in the pending action data.

What's more, when a pending action is created (by the user, the router or another contract), only two entities can validate this pending action: The “to” or the entities that opened it in the past.