### PR TITLE
refactor(core): inline _pnlAsset and optimize _longAssetAvailable

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolCore.sol
+++ b/src/UsdnProtocol/UsdnProtocolCore.sol
@@ -310,9 +310,9 @@ abstract contract UsdnProtocolCore is IUsdnProtocolCore, UsdnProtocolStorage {
         if (balanceLong >= totalExpo) {
             return balanceLong.toInt256();
         }
-        // below, balanceLong is stringly inferior to totalExpo
         int256 priceDiff = _toInt256(newPrice) - _toInt256(oldPrice);
         uint256 tradingExpo;
+        // balanceLong is strictly inferior to totalExpo
         unchecked {
             tradingExpo = totalExpo - balanceLong;
         }


### PR DESCRIPTION
`_pnlAsset` was used in only one place so it has been inlined.

Also, the `_longAssetAvailable` function could be optimized and simplified since some of the checks were not needed anymore.