### PR TITLE
fix: use `_lastPrice` for USDN rebase

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolActions.sol
+++ b/src/UsdnProtocol/UsdnProtocolActions.sol
@@ -2047,8 +2047,7 @@ abstract contract UsdnProtocolActions is IUsdnProtocolActions, UsdnProtocolLong 
             _balanceLong = liquidationEffects.newLongBalance;
             _balanceVault = liquidationEffects.newVaultBalance;
 
-            // safecast not needed since done above
-            (bool rebased, bytes memory callbackResult) = _usdnRebase(uint128(neutralPrice), ignoreInterval);
+            (bool rebased, bytes memory callbackResult) = _usdnRebase(_lastPrice, ignoreInterval);
 
             if (liquidationEffects.liquidatedTicks > 0) {
                 _sendRewardsToLiquidator(


### PR DESCRIPTION
It's not a massive difference and no security concern, but for consistency it's better if we use `_lastPrice` for the rebase.

We will optimize the SLOADs later, since at the moment caching it causes a stack too deep error.