### PR TITLE
feat(liquidation-rewards-manager): add the setting for the rebalancer trigger's gas used

### DIFF
--- a/src/OracleMiddleware/LiquidationRewardsManager.sol
+++ b/src/OracleMiddleware/LiquidationRewardsManager.sol
@@ -55,6 +55,7 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, ChainlinkOracl
             gasUsedPerTick: 36_884,
             otherGasUsed: 306_685,
             rebaseGasUsed: 12_014,
+            rebalancerGasUsed: 0,
             gasPriceLimit: 1000 gwei,
             multiplierBps: 30_000
         });
@@ -101,6 +102,7 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, ChainlinkOracl
         uint32 gasUsedPerTick,
         uint32 otherGasUsed,
         uint32 rebaseGasUsed,
+        uint32 rebalancerGasUsed,
         uint64 gasPriceLimit,
         uint32 multiplierBps
     ) external onlyOwner {
@@ -110,6 +112,8 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, ChainlinkOracl
             revert LiquidationRewardsManagerOtherGasUsedTooHigh(otherGasUsed);
         } else if (rebaseGasUsed > 200_000) {
             revert LiquidationRewardsManagerRebaseGasUsedTooHigh(rebaseGasUsed);
+        } else if (rebalancerGasUsed > 300_000) {
+            revert LiquidationRewardsManagerRebalancerGasUsedTooHigh(rebalancerGasUsed);
         } else if (gasPriceLimit > 8000 gwei) {
             revert LiquidationRewardsManagerGasPriceLimitTooHigh(gasPriceLimit);
         } else if (multiplierBps > 10 * BPS_DIVISOR) {
@@ -120,11 +124,14 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, ChainlinkOracl
             gasUsedPerTick: gasUsedPerTick,
             otherGasUsed: otherGasUsed,
             rebaseGasUsed: rebaseGasUsed,
+            rebalancerGasUsed: rebalancerGasUsed,
             gasPriceLimit: gasPriceLimit,
             multiplierBps: multiplierBps
         });
 
-        emit RewardsParametersUpdated(gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps);
+        emit RewardsParametersUpdated(
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
+        );
     }
 
     /**

--- a/src/interfaces/OracleMiddleware/ILiquidationRewardsManager.sol
+++ b/src/interfaces/OracleMiddleware/ILiquidationRewardsManager.sol
@@ -37,6 +37,7 @@ interface ILiquidationRewardsManager is IBaseLiquidationRewardsManager, ILiquida
      * @param gasUsedPerTick Gas used per tick liquidated
      * @param otherGasUsed Gas used for the rest of the computation
      * @param rebaseGasUsed Gas used for the optional USDN rebase
+     * @param rebalancerGasUsed Gas used for the optional rebalancer trigger
      * @param gasPriceLimit Upper limit for the gas price
      * @param multiplierBps Multiplier for the rewards (will be divided by BPS_DIVISOR)
      */
@@ -44,6 +45,7 @@ interface ILiquidationRewardsManager is IBaseLiquidationRewardsManager, ILiquida
         uint32 gasUsedPerTick,
         uint32 otherGasUsed,
         uint32 rebaseGasUsed,
+        uint32 rebalancerGasUsed,
         uint64 gasPriceLimit,
         uint32 multiplierBps
     ) external;

--- a/src/interfaces/OracleMiddleware/ILiquidationRewardsManagerErrorsEventsTypes.sol
+++ b/src/interfaces/OracleMiddleware/ILiquidationRewardsManagerErrorsEventsTypes.sol
@@ -11,11 +11,17 @@ interface ILiquidationRewardsManagerErrorsEventsTypes {
      * @param gasUsedPerTick Gas used per tick to liquidate
      * @param otherGasUsed Gas used for the rest of the computation
      * @param rebaseGasUsed Gas used for the optional USDN rebase
+     * @param rebalancerGasUsed Gas used for the optional rebalancer trigger
      * @param gasPriceLimit Upper limit for the gas price
      * @param multiplierBps Multiplier for the liquidators
      */
     event RewardsParametersUpdated(
-        uint32 gasUsedPerTick, uint32 otherGasUsed, uint32 rebaseGasUsed, uint64 gasPriceLimit, uint32 multiplierBps
+        uint32 gasUsedPerTick,
+        uint32 otherGasUsed,
+        uint32 rebaseGasUsed,
+        uint32 rebalancerGasUsed,
+        uint64 gasPriceLimit,
+        uint32 multiplierBps
     );
 
     /* -------------------------------------------------------------------------- */
@@ -27,6 +33,7 @@ interface ILiquidationRewardsManagerErrorsEventsTypes {
      * @param gasUsedPerTick Gas used per tick to liquidate
      * @param otherGasUsed Gas used for the rest of the computation
      * @param rebaseGasUsed Gas used for the optional USDN rebase
+     * @param rebalancerGasUsed Gas used for the optional rebalancer trigger
      * @param gasPriceLimit Upper limit for the gas price
      * @param multiplierBps Multiplier basis points for the liquidator rewards
      */
@@ -34,6 +41,7 @@ interface ILiquidationRewardsManagerErrorsEventsTypes {
         uint32 gasUsedPerTick;
         uint32 otherGasUsed;
         uint32 rebaseGasUsed;
+        uint32 rebalancerGasUsed;
         uint64 gasPriceLimit;
         uint32 multiplierBps;
     }
@@ -59,6 +67,12 @@ interface ILiquidationRewardsManagerErrorsEventsTypes {
      * @param value The wanted value
      */
     error LiquidationRewardsManagerRebaseGasUsedTooHigh(uint256 value);
+
+    /**
+     * @notice Indicates that the rebalancerGasUsed parameter has been set to a value we consider too high
+     * @param value The wanted value
+     */
+    error LiquidationRewardsManagerRebalancerGasUsedTooHigh(uint256 value);
 
     /**
      * @notice Indicates that the gasPriceLimit parameter has been set to a value we consider too high

--- a/test/unit/Middlewares/LiquidationRewardsManager/GetLiquidationRewards.t.sol
+++ b/test/unit/Middlewares/LiquidationRewardsManager/GetLiquidationRewards.t.sol
@@ -13,7 +13,7 @@ contract TestLiquidationRewardsManagerGetLiquidationRewards is LiquidationReward
         mockChainlinkOnChain.setLastPublishTime(block.timestamp);
 
         // Change The rewards calculations parameters to not be dependent of the initial values
-        liquidationRewardsManager.setRewardsParameters(10_000, 30_000, 20_000, 1000 gwei, 30_000);
+        liquidationRewardsManager.setRewardsParameters(10_000, 30_000, 20_000, 20_000, 1000 gwei, 30_000);
 
         // Puts the gas at 30 gwei
         mockChainlinkOnChain.setLatestRoundData(1, 30 gwei, block.timestamp, 1);

--- a/test/unit/Middlewares/LiquidationRewardsManager/SetRewardsParameters.t.sol
+++ b/test/unit/Middlewares/LiquidationRewardsManager/SetRewardsParameters.t.sol
@@ -30,13 +30,16 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_000;
         uint32 otherGasUsed = 1_000_000;
         uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
 
         vm.expectEmit();
-        emit RewardsParametersUpdated(gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps);
+        emit RewardsParametersUpdated(
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
+        );
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
 
         RewardsParameters memory rewardsParameters = liquidationRewardsManager.getRewardsParameters();
@@ -57,6 +60,7 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_000;
         uint32 otherGasUsed = 1_000_000;
         uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
 
@@ -65,7 +69,7 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         // Revert as USER_1 is not the owner
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, USER_1));
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
     }
 
@@ -79,13 +83,14 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_001;
         uint32 otherGasUsed = 1_000_000;
         uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
 
         // Expect revert when the gas used per tick parameter is too high
         vm.expectRevert(abi.encodeWithSelector(LiquidationRewardsManagerGasUsedPerTickTooHigh.selector, gasUsedPerTick));
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
     }
 
@@ -99,13 +104,14 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_000;
         uint32 otherGasUsed = 1_000_001;
         uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
 
         // Expect revert when the other gas used parameter is too high
         vm.expectRevert(abi.encodeWithSelector(LiquidationRewardsManagerOtherGasUsedTooHigh.selector, otherGasUsed));
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
     }
 
@@ -119,13 +125,37 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_000;
         uint32 otherGasUsed = 1_000_000;
         uint32 rebaseGasUsed = 200_001;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
 
         // Expect revert when the other gas used parameter is too high
         vm.expectRevert(abi.encodeWithSelector(LiquidationRewardsManagerRebaseGasUsedTooHigh.selector, rebaseGasUsed));
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
+        );
+    }
+
+    /**
+     * @custom:scenario Call `setRewardsParameters` reverts when the rebalancerGasUsed is too high
+     * @custom:when The value of rebalancerGasUsed is bigger than the limit
+     * @custom:and The other parameters are within the limits
+     * @custom:then It reverts with a LiquidationRewardsManagerRebalancerGasUsedTooHigh error
+     */
+    function test_RevertWhen_setRewardsParametersWithRebalancerGasUsedTooHigh() public {
+        uint32 gasUsedPerTick = 500_000;
+        uint32 otherGasUsed = 1_000_000;
+        uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_001;
+        uint64 gasPriceLimit = 8000 gwei;
+        uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
+
+        // Expect revert when the other gas used parameter is too high
+        vm.expectRevert(
+            abi.encodeWithSelector(LiquidationRewardsManagerRebalancerGasUsedTooHigh.selector, rebalancerGasUsed)
+        );
+        liquidationRewardsManager.setRewardsParameters(
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
     }
 
@@ -139,13 +169,14 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_000;
         uint32 otherGasUsed = 1_000_000;
         uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei + 1;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR();
 
         // Expect revert when the gas price limit parameter is too high
         vm.expectRevert(abi.encodeWithSelector(LiquidationRewardsManagerGasPriceLimitTooHigh.selector, gasPriceLimit));
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
     }
 
@@ -159,13 +190,14 @@ contract TestLiquidationRewardsManagerSetRewardsParameters is
         uint32 gasUsedPerTick = 500_000;
         uint32 otherGasUsed = 1_000_000;
         uint32 rebaseGasUsed = 200_000;
+        uint32 rebalancerGasUsed = 300_000;
         uint64 gasPriceLimit = 8000 gwei;
         uint32 multiplierBps = 10 * liquidationRewardsManager.BPS_DIVISOR() + 1;
 
         // Expect revert when the value of multiplierBps is too high
         vm.expectRevert(abi.encodeWithSelector(LiquidationRewardsManagerMultiplierBpsTooHigh.selector, multiplierBps));
         liquidationRewardsManager.setRewardsParameters(
-            gasUsedPerTick, otherGasUsed, rebaseGasUsed, gasPriceLimit, multiplierBps
+            gasUsedPerTick, otherGasUsed, rebaseGasUsed, rebalancerGasUsed, gasPriceLimit, multiplierBps
         );
     }
 }

--- a/test/unit/UsdnProtocol/Actions/Liquidation.t.sol
+++ b/test/unit/UsdnProtocol/Actions/Liquidation.t.sol
@@ -462,7 +462,7 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
 
         // Change The rewards calculations parameters to not be dependent of the initial values
         vm.prank(DEPLOYER);
-        liquidationRewardsManager.setRewardsParameters(10_000, 30_000, 20_000, 1000 gwei, 20_000);
+        liquidationRewardsManager.setRewardsParameters(10_000, 30_000, 20_000, 20_000, 1000 gwei, 20_000);
 
         uint256 expectedLiquidatorRewards =
             liquidationRewardsManager.getLiquidationRewards(1, 0, false, ProtocolAction.None, "", "");
@@ -530,7 +530,7 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
         // Change The rewards calculations parameters to not be dependent of the initial values
         vm.prank(DEPLOYER);
         // Put incredibly high values to empty the vault
-        liquidationRewardsManager.setRewardsParameters(500_000, 1_000_000, 200_000, 8000 gwei, 20_000);
+        liquidationRewardsManager.setRewardsParameters(500_000, 1_000_000, 200_000, 200_000, 8000 gwei, 20_000);
 
         uint256 wstETHBalanceBeforeRewards = wstETH.balanceOf(address(this));
         uint256 vaultBalanceBeforeRewards = protocol.getBalanceVault();
@@ -613,7 +613,7 @@ contract TestUsdnProtocolLiquidation is UsdnProtocolBaseFixture {
 
         // disable rewards
         vm.prank(DEPLOYER);
-        liquidationRewardsManager.setRewardsParameters(0, 0, 0, 1000 gwei, 0);
+        liquidationRewardsManager.setRewardsParameters(0, 0, 0, 0, 1000 gwei, 0);
 
         // liquidate
         uint256 balanceBefore = address(this).balance;


### PR DESCRIPTION
When a liquidation triggers the rebalancer, the added gas cost should be added to the rewards calculation.

(To save some time on this task, I'll do this part first since it doesn't touch anything in the USDN protocol's contracts)