### PR TITLE
fix(rebalancer)!: disallow choosing the validator address on closing

### DIFF
--- a/src/Rebalancer/Rebalancer.sol
+++ b/src/Rebalancer/Rebalancer.sol
@@ -419,7 +419,6 @@ contract Rebalancer is Ownable2Step, ReentrancyGuard, ERC165, IOwnershipCallback
     function initiateClosePosition(
         uint88 amount,
         address to,
-        address payable validator,
         bytes calldata currentPriceData,
         Types.PreviousActionsData calldata previousActionsData
     ) external payable nonReentrant returns (bool success_) {
@@ -479,7 +478,7 @@ contract Rebalancer is Ownable2Step, ReentrancyGuard, ERC165, IOwnershipCallback
             }),
             data.amountToClose.toUint128(),
             to,
-            validator,
+            payable(msg.sender),
             currentPriceData,
             previousActionsData
         );

--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
@@ -329,7 +329,8 @@ library UsdnProtocolActionsUtilsLibrary {
         if (remainingAmount > 0 && remainingAmount < s._minLongPosition) {
             IBaseRebalancer rebalancer = s._rebalancer;
             if (owner == address(rebalancer)) {
-                uint128 userPosAmount = rebalancer.getUserDepositData(to).amount;
+                // note: the rebalancer always indicates the rebalancer user's address as validator
+                uint128 userPosAmount = rebalancer.getUserDepositData(validator).amount;
                 if (amountToClose != userPosAmount) {
                     revert IUsdnProtocolErrors.UsdnProtocolLongPositionTooSmall();
                 }

--- a/src/interfaces/Rebalancer/IRebalancer.sol
+++ b/src/interfaces/Rebalancer/IRebalancer.sol
@@ -126,9 +126,10 @@ interface IRebalancer is IBaseRebalancer, IRebalancerErrors, IRebalancerEvents, 
      * @notice Closes a user deposited amount of the current UsdnProtocol rebalancer position
      * @dev The rebalancer allows partially closing its position to withdraw the user's assets + PnL
      * The remaining amount needs to be above `_minAssetDeposit` and `_minLongPosition` on the USDN protocol side
+     * The validator is always the msg.sender, which means the user must call `validateClosePosition` on the protocol
+     * side after calling this function
      * @param amount The amount to close relative to the amount deposited
-     * @param to The to address
-     * @param validator The validator address
+     * @param to The address that will receive the assets
      * @param currentPriceData The current price data
      * @param previousActionsData The previous action price data
      * @return success_ If the UsdnProtocol's `initiateClosePosition` was successful
@@ -138,7 +139,6 @@ interface IRebalancer is IBaseRebalancer, IRebalancerErrors, IRebalancerEvents, 
     function initiateClosePosition(
         uint88 amount,
         address to,
-        address payable validator,
         bytes calldata currentPriceData,
         Types.PreviousActionsData calldata previousActionsData
     ) external payable returns (bool success_);

--- a/test/integration/UsdnProtocol/RebalancerInitiateClosePosition.t.sol
+++ b/test/integration/UsdnProtocol/RebalancerInitiateClosePosition.t.sol
@@ -80,7 +80,7 @@ contract TestRebalancerInitiateClosePosition is
         vm.expectEmit();
         emit ClosePositionInitiated(address(this), amount, amountToClose, amountInRebalancer - amount);
         (bool success) = rebalancer.initiateClosePosition{ value: protocol.getSecurityDepositValue() }(
-            amount, address(this), payable(address(this)), "", EMPTY_PREVIOUS_DATA
+            amount, address(this), "", EMPTY_PREVIOUS_DATA
         );
 
         assertTrue(success, "The rebalancer close should be successful");
@@ -137,7 +137,7 @@ contract TestRebalancerInitiateClosePosition is
         vm.expectEmit();
         emit ClosePositionInitiated(address(this), amountInRebalancer, amountToClose, 0);
         (bool success) = rebalancer.initiateClosePosition{ value: protocol.getSecurityDepositValue() }(
-            amountInRebalancer, address(this), payable(this), "", EMPTY_PREVIOUS_DATA
+            amountInRebalancer, address(this), "", EMPTY_PREVIOUS_DATA
         );
 
         UserDeposit memory depositData = rebalancer.getUserDepositData(address(this));
@@ -174,7 +174,7 @@ contract TestRebalancerInitiateClosePosition is
 
         // send more ether than necessary to trigger the refund
         rebalancer.initiateClosePosition{ value: securityDeposit + excessAmount }(
-            amountInRebalancer, address(this), payable(this), "", EMPTY_PREVIOUS_DATA
+            amountInRebalancer, address(this), "", EMPTY_PREVIOUS_DATA
         );
 
         assertEq(payable(rebalancer).balance, 0, "There should be no ether left in the rebalancer");

--- a/test/unit/Rebalancer/InitiateClosePosition.t.sol
+++ b/test/unit/Rebalancer/InitiateClosePosition.t.sol
@@ -27,9 +27,9 @@ contract TestRebalancerInitiateClosePosition is RebalancerFixture {
      * @custom:when The `initiateClosePosition` function is called with zero amount
      * @custom:then It should revert with `RebalancerInvalidAmount`
      */
-    function test_RevertWhen_rebalancerInvalidAmountZero() external {
+    function test_RevertWhen_rebalancerInvalidAmountZero() public {
         vm.expectRevert(IRebalancerErrors.RebalancerInvalidAmount.selector);
-        rebalancer.initiateClosePosition(0, address(this), payable(address(this)), "", EMPTY_PREVIOUS_DATA);
+        rebalancer.initiateClosePosition(0, address(this), "", EMPTY_PREVIOUS_DATA);
     }
 
     /**
@@ -37,9 +37,9 @@ contract TestRebalancerInitiateClosePosition is RebalancerFixture {
      * @custom:when The `initiateClosePosition` function is called with more than the user rebalancer amount
      * @custom:then It should revert with `RebalancerInvalidAmount`
      */
-    function test_RevertWhen_rebalancerInvalidAmountTooLarge() external {
+    function test_RevertWhen_rebalancerInvalidAmountTooLarge() public {
         vm.expectRevert(IRebalancerErrors.RebalancerInvalidAmount.selector);
-        rebalancer.initiateClosePosition(minAsset + 1, address(this), payable(address(this)), "", EMPTY_PREVIOUS_DATA);
+        rebalancer.initiateClosePosition(minAsset + 1, address(this), "", EMPTY_PREVIOUS_DATA);
     }
 
     /**
@@ -48,9 +48,9 @@ contract TestRebalancerInitiateClosePosition is RebalancerFixture {
      * lower than the rebalancer minimum amount
      * @custom:then It should revert with `RebalancerInvalidAmount`
      */
-    function test_RevertWhen_rebalancerInvalidAmountTooLow() external {
+    function test_RevertWhen_rebalancerInvalidAmountTooLow() public {
         vm.expectRevert(IRebalancerErrors.RebalancerInvalidAmount.selector);
-        rebalancer.initiateClosePosition(1, address(this), payable(address(this)), "", EMPTY_PREVIOUS_DATA);
+        rebalancer.initiateClosePosition(1, address(this), "", EMPTY_PREVIOUS_DATA);
     }
 
     /**
@@ -58,8 +58,8 @@ contract TestRebalancerInitiateClosePosition is RebalancerFixture {
      * @custom:when The `initiateClosePosition` function is called with pending assets
      * @custom:then It should revert with `RebalancerUserPending`
      */
-    function test_RevertWhen_rebalancerUserPending() external {
+    function test_RevertWhen_rebalancerUserPending() public {
         vm.expectRevert(IRebalancerErrors.RebalancerUserPending.selector);
-        rebalancer.initiateClosePosition(minAsset, address(this), payable(address(this)), "", EMPTY_PREVIOUS_DATA);
+        rebalancer.initiateClosePosition(minAsset, address(this), "", EMPTY_PREVIOUS_DATA);
     }
 }


### PR DESCRIPTION
Users of the rebalancer should be allowed to fully close their position, even if that leaves the rebalancer position below the `_minLongAmount` of the protocol. To perform this check, we were previously looking at the rebalancer deposit of the `to` address. This left the protocol subject to an attack whereby a user of the rebalancer could indicate the address of another rebalancer user as the `to` to change the way the checks are performed. Now, we force the `validator` to be the rebalancer user's address, and we check the close amount condition by checking the validator deposit inside the rebalancer.

BREAKING CHANGE: the `IRebalancer.initiateClosePosition` function does not have a `validator` parameter anymore