### PR TITLE
refactor!: remove an error for the zero amount check in initiateClosePosition to use an existing one

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
@@ -319,6 +319,9 @@ library UsdnProtocolActionsUtilsLibrary {
         if (!pos.validated) {
             revert IUsdnProtocolErrors.UsdnProtocolPositionNotValidated();
         }
+        if (amountToClose == 0) {
+            revert IUsdnProtocolErrors.UsdnProtocolZeroAmount();
+        }
         if (amountToClose > pos.amount) {
             revert IUsdnProtocolErrors.UsdnProtocolAmountToCloseHigherThanPositionAmount(amountToClose, pos.amount);
         }
@@ -337,9 +340,6 @@ library UsdnProtocolActionsUtilsLibrary {
             } else {
                 revert IUsdnProtocolErrors.UsdnProtocolLongPositionTooSmall();
             }
-        }
-        if (amountToClose == 0) {
-            revert IUsdnProtocolErrors.UsdnProtocolAmountToCloseIsZero();
         }
     }
 

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolErrors.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolErrors.sol
@@ -187,9 +187,6 @@ interface IUsdnProtocolErrors {
      */
     error UsdnProtocolAmountToCloseHigherThanPositionAmount(uint128 amountToClose, uint128 positionAmount);
 
-    /// @dev Indicates that the amount to close in a position is zero
-    error UsdnProtocolAmountToCloseIsZero();
-
     /// @dev Indicates that the deposit amount is too small, leading to no USDN minted or no SDEX burned
     error UsdnProtocolDepositTooSmall();
 

--- a/test/unit/UsdnProtocol/Actions/InitiateClosePosition.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InitiateClosePosition.t.sol
@@ -121,7 +121,7 @@ contract TestUsdnProtocolActionsInitiateClosePosition is UsdnProtocolBaseFixture
     function test_RevertWhen_closePartialPositionWithZeroAmount() public {
         bytes memory priceData = abi.encode(params.initialPrice);
 
-        vm.expectRevert(abi.encodeWithSelector(UsdnProtocolAmountToCloseIsZero.selector));
+        vm.expectRevert(abi.encodeWithSelector(UsdnProtocolZeroAmount.selector));
         protocol.i_initiateClosePosition(address(this), address(this), address(this), posId, 0, 0, priceData);
     }
 

--- a/test/unit/UsdnProtocol/Actions/_CheckInitiateClosePosition.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_CheckInitiateClosePosition.t.sol
@@ -115,10 +115,10 @@ contract TestUsdnProtocolCheckInitiateClosePosition is UsdnProtocolBaseFixture, 
     /**
      * @custom:scenario Check an initiate close of a position with zero amount
      * @custom:when The user initiates a close position with an amount of zero
-     * @custom:then The function should revert with `UsdnProtocolAmountToCloseIsZero`
+     * @custom:then The function should revert with `UsdnProtocolZeroAmount`
      */
     function test_RevertWhen_checkInitiateClosePositionAmountZero() public {
-        vm.expectRevert(UsdnProtocolAmountToCloseIsZero.selector);
+        vm.expectRevert(UsdnProtocolZeroAmount.selector);
         protocol.i_checkInitiateClosePosition(address(this), USER_1, USER_2, 0, pos);
     }
 


### PR DESCRIPTION
This error was used only in `initiateClosePosition`, all the other actions use `UsdnProtocolZeroAmount`, but I couldn't find a reason to keep this error and not use the existing one.

BREAKING CHANGE: Remove the error `UsdnProtocolAmountToCloseIsZero` to use `UsdnProtocolZeroAmount` instead in `initiateClosePosition`