### PR TITLE
test: run heavy_ci on main

### DIFF
--- a/.github/workflows/heavy_ci.yml
+++ b/.github/workflows/heavy_ci.yml
@@ -1,6 +1,8 @@
 name: CI with heavy test run
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 env:
   FOUNDRY_PROFILE: heavy_ci


### PR DESCRIPTION
That would be nice to be notified when a PR that got merged breaks the FFI or Fork tests. 

As the heavy CI is pretty slow, we could do it only once the PR is merged, and run it on main, then tag the author of the merged PR