### PR TITLE
feat(rebalancer)!: add additional attributes to the PositionVersionUpdated event

### DIFF
--- a/src/Rebalancer/Rebalancer.sol
+++ b/src/Rebalancer/Rebalancer.sol
@@ -564,7 +564,7 @@ contract Rebalancer is Ownable2Step, ReentrancyGuard, ERC165, IOwnershipCallback
             _positionData[positionVersion].tick = Constants.NO_POSITION_TICK;
         }
 
-        emit PositionVersionUpdated(positionVersion, accMultiplier, positionAmount);
+        emit PositionVersionUpdated(positionVersion, accMultiplier, positionAmount, newPosId);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/interfaces/Rebalancer/IRebalancerEvents.sol
+++ b/src/interfaces/Rebalancer/IRebalancerEvents.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
+import { IUsdnProtocolTypes as Types } from "../../interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
+
 interface IRebalancerEvents {
     /**
      * @notice Emitted when a user initiates a deposit into the Rebalancer
@@ -69,8 +71,11 @@ interface IRebalancerEvents {
      * @param newPositionVersion The new version of the position
      * @param entryAccMultiplier The accumulated multiplier at the opening of the new version
      * @param amount The amount of assets the rebalancer injected in the position as collateral
+     * @param positionId The ID of the new position in the USDN protocol
      */
-    event PositionVersionUpdated(uint128 newPositionVersion, uint256 entryAccMultiplier, uint128 amount);
+    event PositionVersionUpdated(
+        uint128 newPositionVersion, uint256 entryAccMultiplier, uint128 amount, Types.PositionId positionId
+    );
 
     /**
      * @notice Emitted when the close imbalance limit in bps is updated

--- a/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
+++ b/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
@@ -241,7 +241,7 @@ contract TestForkUsdnProtocolLiquidationGasUsage is
 
                 // sanity check, make sure the rebalancer was triggered
                 vm.expectEmit(false, false, false, false);
-                emit PositionVersionUpdated(0, 0, 0);
+                emit PositionVersionUpdated(0, 0, 0, PositionId(0, 0, 0));
             }
 
             uint256 startGas = gasleft();

--- a/test/integration/UsdnProtocol/RebalancerTrigger.t.sol
+++ b/test/integration/UsdnProtocol/RebalancerTrigger.t.sol
@@ -160,6 +160,7 @@ contract TestUsdnProtocolRebalancerTrigger is UsdnProtocolBaseIntegrationFixture
     ) internal {
         uint128 positionTotalExpo = protocol.i_calcPositionTotalExpo(amount + bonus, price, liqPriceWithoutPenalty);
         uint256 defaultAccMultiplier = rebalancer.MULTIPLIER_FACTOR();
+        PositionId memory expectedPositionId = PositionId(tick, 0, 0);
 
         vm.expectEmit(false, false, false, false);
         emit LiquidatedTick(0, 0, 0, 0, 0);
@@ -171,14 +172,14 @@ contract TestUsdnProtocolRebalancerTrigger is UsdnProtocolBaseIntegrationFixture
             positionTotalExpo,
             amount + bonus,
             price,
-            PositionId(tick, 0, 0)
+            expectedPositionId
         );
         vm.expectEmit(address(protocol));
         emit ValidatedOpenPosition(
-            address(rebalancer), address(rebalancer), positionTotalExpo, price, PositionId(tick, 0, 0)
+            address(rebalancer), address(rebalancer), positionTotalExpo, price, expectedPositionId
         );
         vm.expectEmit(address(rebalancer));
-        emit PositionVersionUpdated(newPositionVersion, defaultAccMultiplier, amount);
+        emit PositionVersionUpdated(newPositionVersion, defaultAccMultiplier, amount, expectedPositionId);
     }
 
     receive() external payable { }

--- a/test/unit/Rebalancer/UpdatePosition.t.sol
+++ b/test/unit/Rebalancer/UpdatePosition.t.sol
@@ -76,7 +76,7 @@ contract TestRebalancerUpdatePosition is RebalancerFixture {
 
         vm.prank(address(usdnProtocol));
         vm.expectEmit();
-        emit PositionVersionUpdated(positionVersionBefore + 1, defaultAccMultiplier, pendingAssetsBefore);
+        emit PositionVersionUpdated(positionVersionBefore + 1, defaultAccMultiplier, pendingAssetsBefore, newPosId);
         rebalancer.updatePosition(newPosId, 0);
 
         // check the position data
@@ -132,7 +132,7 @@ contract TestRebalancerUpdatePosition is RebalancerFixture {
         uint256 expectedEntryAccMul = rebalancer.MULTIPLIER_FACTOR() * 11 / 10;
         vm.expectEmit();
         emit PositionVersionUpdated(
-            positionVersionBefore + 2, expectedEntryAccMul, posVersion2Value + user2DepositedAmount
+            positionVersionBefore + 2, expectedEntryAccMul, posVersion2Value + user2DepositedAmount, posId2
         );
         vm.prank(address(usdnProtocol));
         rebalancer.updatePosition(posId2, posVersion2Value);
@@ -184,7 +184,10 @@ contract TestRebalancerUpdatePosition is RebalancerFixture {
 
         vm.expectEmit();
         emit PositionVersionUpdated(
-            positionVersionBefore + 2, rebalancer.MULTIPLIER_FACTOR(), USER_0_DEPOSIT_AMOUNT + USER_1_DEPOSIT_AMOUNT
+            positionVersionBefore + 2,
+            rebalancer.MULTIPLIER_FACTOR(),
+            USER_0_DEPOSIT_AMOUNT + USER_1_DEPOSIT_AMOUNT,
+            posId2
         );
         vm.prank(address(usdnProtocol));
         // 0 as a value here means there was no collateral left in the closed position
@@ -222,7 +225,9 @@ contract TestRebalancerUpdatePosition is RebalancerFixture {
         uint128 positionVersionBefore = rebalancer.getPositionVersion();
 
         vm.expectEmit();
-        emit PositionVersionUpdated(positionVersionBefore + 1, rebalancer.MULTIPLIER_FACTOR(), 0);
+        emit PositionVersionUpdated(
+            positionVersionBefore + 1, rebalancer.MULTIPLIER_FACTOR(), 0, Types.PositionId(noPositionTick, 0, 0)
+        );
         rebalancer.updatePosition(Types.PositionId(noPositionTick, 0, 0), 0);
         vm.stopPrank();
 


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
So the backend doesn't have to make RPC calls just to get those information.

BREAKING CHANGE: The `PositionVersionUpdated` event now has 4 attributes instead of 1. `entryAccMultiplier` which the is value of the accumulated multiplier at the opening of the position. `amount` which is the amount of assets in the new position (without the bonus taken from the liquidation penalty). `positionId` which is the tick/tickVersion/index of the position in the USDN protocol (in the `PositionId` type format).
END_COMMIT_OVERRIDE