### PR TITLE
chore: fix manual prerelease codeartifact package version

### DIFF
--- a/.github/workflows/manual_prerelease.yml
+++ b/.github/workflows/manual_prerelease.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci && forge install
 
       - name: Update package version
-        run: npm version prerelease --no-git-tag-version --preid "${{github.ref_name}}.${{ github.sha }}"
+        run: npm version prerelease --no-git-tag-version --preid "$(echo ${{ github.ref_name }} | sed 's/[[:alnum:]]\{1,\}\///').${{ github.sha }}"
 
       - name: Export ABI
         run: npm run exportAbi


### PR DESCRIPTION
Attempt to fix version tag when using branch other than `main`
See [Manual Pre-release Action](https://github.com/SmarDex-Ecosystem/usdn-contracts/actions/runs/9874372358/job/27268616177#step:10:14)

```
// Before
branch: `feature/new-field-in-this-contract`
output: `0.16.1-feature/new-field-in-this-contract.SHA...`
```
```
// After
branch: `feature/new-field-in-this-contract`
output: `0.16.1-new-field-in-this-contract.SHA...`
```