### PR TITLE
test: add visibility modifiers

### DIFF
--- a/test/integration/UsdnProtocol/RebalancerInitiateClosePosition.t.sol
+++ b/test/integration/UsdnProtocol/RebalancerInitiateClosePosition.t.sol
@@ -50,7 +50,7 @@ contract TestRebalancerInitiateClosePosition is
         posAmount = protocolPosition.amount;
     }
 
-    function test_setUp() public {
+    function test_setUp() public view {
         assertGt(rebalancer.getPositionVersion(), 0, "The rebalancer version should be updated");
         assertGt(posAmount - previousPositionData.amount, 0, "The protocol bonus should be positive");
     }

--- a/test/unit/DoubleEndedQueue/Empty.t.sol
+++ b/test/unit/DoubleEndedQueue/Empty.t.sol
@@ -19,7 +19,7 @@ contract TestDequeEmpty is DequeFixture {
      * @custom:when Calling `empty` and `length`
      * @custom:then Returns `true` and `0`
      */
-    function test_view() public {
+    function test_view() public view {
         assertEq(handler.empty(), true, "empty");
         assertEq(handler.length(), 0, "length");
     }

--- a/test/unit/DoubleEndedQueue/Populated.t.sol
+++ b/test/unit/DoubleEndedQueue/Populated.t.sol
@@ -59,7 +59,7 @@ contract TestDequePopulated is DequeFixture {
      * @custom:when Calling `empty` and `length`
      * @custom:then Returns `false` and `3`
      */
-    function test_view() public {
+    function test_view() public view {
         assertEq(handler.empty(), false, "empty");
         assertEq(handler.length(), 3, "length");
     }
@@ -69,7 +69,7 @@ contract TestDequePopulated is DequeFixture {
      * @custom:when Calling `front`
      * @custom:then Returns the front item
      */
-    function test_accessFront() public {
+    function test_accessFront() public view {
         (Types.PendingAction memory front, uint128 rawIndex) = handler.front();
         _assertActionsEqual(front, action1, "front");
         assertEq(rawIndex, rawIndex1, "raw index");
@@ -80,7 +80,7 @@ contract TestDequePopulated is DequeFixture {
      * @custom:when Calling `back`
      * @custom:then Returns the back item
      */
-    function test_accessBack() public {
+    function test_accessBack() public view {
         (Types.PendingAction memory back, uint128 rawIndex) = handler.back();
         _assertActionsEqual(back, action3, "back");
         assertEq(rawIndex, rawIndex3, "raw index");
@@ -91,7 +91,7 @@ contract TestDequePopulated is DequeFixture {
      * @custom:when Calling `at` with one of the indices
      * @custom:then Returns the item at the given index
      */
-    function test_accessAt() public {
+    function test_accessAt() public view {
         (Types.PendingAction memory at, uint128 rawIndex) = handler.at(0);
         _assertActionsEqual(at, action1, "action 1");
         assertEq(rawIndex, rawIndex1, "raw index 1");
@@ -108,7 +108,7 @@ contract TestDequePopulated is DequeFixture {
      * @custom:when Calling `atRaw` with one of the raw indices
      * @custom:then Returns the item at the given raw index
      */
-    function test_accessAtRaw() public {
+    function test_accessAtRaw() public view {
         _assertActionsEqual(handler.atRaw(rawIndex1), action1, "action 1");
         _assertActionsEqual(handler.atRaw(rawIndex2), action2, "action 2");
         _assertActionsEqual(handler.atRaw(rawIndex3), action3, "action 3");

--- a/test/unit/DoubleEndedQueue/utils/Fixtures.sol
+++ b/test/unit/DoubleEndedQueue/utils/Fixtures.sol
@@ -26,6 +26,7 @@ contract DequeFixture is BaseFixture {
      */
     function _assertActionsEqual(Types.PendingAction memory a, Types.PendingAction memory b, string memory err)
         internal
+        pure
     {
         assertTrue(a.action == b.action, string.concat(err, " - action type"));
         assertEq(a.timestamp, b.timestamp, string.concat(err, " - action timestamp"));

--- a/test/unit/HugeUint/Add.t.sol
+++ b/test/unit/HugeUint/Add.t.sol
@@ -21,7 +21,7 @@ contract TestHugeUintAdd is HugeUintFixture {
      * @custom:when The `add` function is called with `uint512.max/2` and `uint512.max/2`
      * @custom:then The result is equal to `uint512.max - 1`
      */
-    function test_add() public {
+    function test_add() public view {
         HugeUint.Uint512 memory a = HugeUint.wrap(42);
         HugeUint.Uint512 memory b = HugeUint.wrap(420);
         HugeUint.Uint512 memory res = handler.add(a, b);

--- a/test/unit/HugeUint/Div256.t.sol
+++ b/test/unit/HugeUint/Div256.t.sol
@@ -24,7 +24,7 @@ contract TestHugeUintDiv256 is HugeUintFixture {
      * @custom:when The `div` function is called with `<uint256.max - 1, uint256.max>` and `uint256.max`
      * @custom:then The result is equal to `uint256.max`
      */
-    function test_div() public {
+    function test_div() public view {
         HugeUint.Uint512 memory a = HugeUint.Uint512(0, 1);
         uint256 b = 10;
         uint256 res = handler.div(a, b);

--- a/test/unit/HugeUint/Div512.t.sol
+++ b/test/unit/HugeUint/Div512.t.sol
@@ -26,7 +26,7 @@ contract TestHugeUintDiv512 is HugeUintFixture {
      * @custom:then The result is equal to `uint256.max` (note that this is larger than uint256.max, but does not
      * overflow due to rounding down)
      */
-    function test_div() public {
+    function test_div() public view {
         HugeUint.Uint512 memory a = HugeUint.Uint512(0, 69);
         HugeUint.Uint512 memory b = HugeUint.Uint512(0, 42);
         uint256 res = HugeUint.div(a, b);

--- a/test/unit/HugeUint/Fuzzing.t.sol
+++ b/test/unit/HugeUint/Fuzzing.t.sol
@@ -336,7 +336,7 @@ contract TestHugeUintFuzzing is HugeUintFixture {
      * @param a the first operand
      * @param b the second operand
      */
-    function testFuzz_mulThenDiv(uint256 a, uint256 b) public {
+    function testFuzz_mulThenDiv(uint256 a, uint256 b) public view {
         vm.assume(a > 0 && b > 0);
         HugeUint.Uint512 memory m = handler.mul(a, b);
         uint256 res = handler.div(m, b);

--- a/test/unit/HugeUint/Mul256.t.sol
+++ b/test/unit/HugeUint/Mul256.t.sol
@@ -23,7 +23,7 @@ contract TestHugeUintMul256 is HugeUintFixture {
      * @custom:when The `mul` function is called with 0 and 1
      * @custom:then The result is equal to 0
      */
-    function test_mul() public {
+    function test_mul() public view {
         uint256 a = 42;
         uint256 b = 420;
         HugeUint.Uint512 memory res = handler.mul(a, b);

--- a/test/unit/HugeUint/Mul512.t.sol
+++ b/test/unit/HugeUint/Mul512.t.sol
@@ -29,7 +29,7 @@ contract TestHugeUintMul512 is HugeUintFixture {
      * @custom:when The `mul` function is called with `uint256.max+2` and `uint256.max`
      * @custom:then The result is equal to `uint512.max`
      */
-    function test_mul() public {
+    function test_mul() public view {
         HugeUint.Uint512 memory a = HugeUint.Uint512(0, 69);
         uint256 b = 42;
         HugeUint.Uint512 memory res = handler.mul(a, b);

--- a/test/unit/HugeUint/Sub.t.sol
+++ b/test/unit/HugeUint/Sub.t.sol
@@ -25,7 +25,7 @@ contract TestHugeUintSub is HugeUintFixture {
      * @custom:when The `sub` function is called with `uint512.max` and 1
      * @custom:then The result is equal to `uint512.max - 1`
      */
-    function test_sub() public {
+    function test_sub() public pure {
         HugeUint.Uint512 memory a = HugeUint.Uint512(0, 69);
         HugeUint.Uint512 memory b = HugeUint.Uint512(0, 42);
         HugeUint.Uint512 memory res = HugeUint.sub(a, b);

--- a/test/unit/Middlewares/LiquidationRewardsManager/GetLiquidationRewards.t.sol
+++ b/test/unit/Middlewares/LiquidationRewardsManager/GetLiquidationRewards.t.sol
@@ -30,7 +30,7 @@ contract TestLiquidationRewardsManagerGetLiquidationRewards is LiquidationReward
      * @custom:then It should return an amount of wstETH based on the gas used by
      * UsdnProtocolActions.liquidate(bytes,uint16)
      */
-    function test_getLiquidationRewardsFor1Tick() public {
+    function test_getLiquidationRewardsFor1Tick() public view {
         uint256 rewards =
             liquidationRewardsManager.getLiquidationRewards(1, 0, false, false, Types.ProtocolAction.None, "", "");
         assertEq(rewards, 2_794_500_000_000_000, "without rebase");
@@ -48,7 +48,7 @@ contract TestLiquidationRewardsManagerGetLiquidationRewards is LiquidationReward
      * @custom:when No ticks were liquidated
      * @custom:then It should return 0 as we only give rewards on successful liquidations
      */
-    function test_getLiquidationRewardsFor0Tick() public {
+    function test_getLiquidationRewardsFor0Tick() public view {
         uint256 rewards =
             liquidationRewardsManager.getLiquidationRewards(0, 0, false, false, Types.ProtocolAction.None, "", "");
         assertEq(rewards, 0, "without rebase");
@@ -67,7 +67,7 @@ contract TestLiquidationRewardsManagerGetLiquidationRewards is LiquidationReward
      * @custom:then It should return more wstETH than for 1 tick as more gas was used by
      * UsdnProtocolActions.liquidate(bytes,uint16)
      */
-    function test_getLiquidationRewardsFor3Ticks() public {
+    function test_getLiquidationRewardsFor3Ticks() public view {
         uint256 rewards =
             liquidationRewardsManager.getLiquidationRewards(3, 0, false, false, Types.ProtocolAction.None, "", "");
         assertEq(rewards, 4_864_500_000_000_000, "The wrong amount of rewards was given");

--- a/test/unit/Middlewares/Oracle/Decimals.t.sol
+++ b/test/unit/Middlewares/Oracle/Decimals.t.sol
@@ -16,7 +16,7 @@ contract TestOracleMiddlewareDecimals is OracleMiddlewareBaseFixture {
      * @custom:when The result of the result of the function is compared to 18
      * @custom:then It should succeed
      */
-    function test_decimals() public {
+    function test_decimals() public view {
         assertEq(oracleMiddleware.getDecimals(), 18);
     }
 
@@ -25,7 +25,7 @@ contract TestOracleMiddlewareDecimals is OracleMiddlewareBaseFixture {
      * @custom:when The result of the result of the function is compared to 8
      * @custom:then It should succeed
      */
-    function test_chainlinkDecimals() public {
+    function test_chainlinkDecimals() public view {
         assertEq(oracleMiddleware.getChainlinkDecimals(), 8);
     }
 }

--- a/test/unit/Middlewares/Oracle/IsPythData.t.sol
+++ b/test/unit/Middlewares/Oracle/IsPythData.t.sol
@@ -15,7 +15,7 @@ contract TestOracleMiddlewareIsPythData is OracleMiddlewareBaseFixture {
      * @custom:when The data has a length lower than or equal to 32 bytes
      * @custom:then The function should return false
      */
-    function test_isPythDataShortBytes() public {
+    function test_isPythDataShortBytes() public view {
         assertFalse(oracleMiddleware.i_isPythData(""), "empty bytes");
         assertFalse(oracleMiddleware.i_isPythData(new bytes(32)), "32 bytes");
     }
@@ -26,7 +26,7 @@ contract TestOracleMiddlewareIsPythData is OracleMiddlewareBaseFixture {
      * @custom:when The data starts with the magic bytes
      * @custom:then The function should return true
      */
-    function test_isPythDataMagic() public {
+    function test_isPythDataMagic() public view {
         assertTrue(oracleMiddleware.i_isPythData(MOCK_PYTH_DATA), "magic data");
     }
 
@@ -36,7 +36,7 @@ contract TestOracleMiddlewareIsPythData is OracleMiddlewareBaseFixture {
      * @custom:when The data has a higher length than 32 bytes
      * @custom:then The function should return false
      */
-    function test_isPythDataLongBytes() public {
+    function test_isPythDataLongBytes() public view {
         assertFalse(oracleMiddleware.i_isPythData(new bytes(33)), "33 bytes");
         assertFalse(oracleMiddleware.i_isPythData(new bytes(64)), "64 bytes");
     }

--- a/test/unit/Middlewares/Oracle/PythFeedId.t.sol
+++ b/test/unit/Middlewares/Oracle/PythFeedId.t.sol
@@ -15,7 +15,7 @@ contract TestOracleMiddlewarePythFeedId is OracleMiddlewareBaseFixture {
      * @custom:when The result of the result of the function is compared to PYTH_ETH_USD
      * @custom:then It should succeed
      */
-    function test_getPythFeedId() public {
+    function test_getPythFeedId() public view {
         assertEq(oracleMiddleware.getPythFeedId(), PYTH_ETH_USD);
     }
 }

--- a/test/unit/Middlewares/Oracle/RedstoneOracle/ExtractPriceUpdateTimestamp.t.sol
+++ b/test/unit/Middlewares/Oracle/RedstoneOracle/ExtractPriceUpdateTimestamp.t.sol
@@ -16,7 +16,7 @@ contract TestRedstoneOracleExtractPriceUpdateTimestamp is OracleMiddlewareBaseFi
      * @custom:when The `extractPriceUpdateTimestamp` function is called with the Redstone message
      * @custom:then It should return the correct timestamp
      */
-    function test_extractPriceUpdateTimestamp() public {
+    function test_extractPriceUpdateTimestamp() public view {
         assertEq(
             oracleMiddleware.i_extractPriceUpdateTimestamp(REDSTONE_ETH_DATA),
             REDSTONE_ETH_TIMESTAMP,

--- a/test/unit/Middlewares/Oracle/SetLowLatencyDelay.t.sol
+++ b/test/unit/Middlewares/Oracle/SetLowLatencyDelay.t.sol
@@ -22,7 +22,7 @@ contract TestOracleMiddlewareSetLowLatencyDelay is OracleMiddlewareBaseFixture {
      * @custom:when The function is called
      * @custom:then It should return the default value
      */
-    function test_getLowLatencyDelay() public {
+    function test_getLowLatencyDelay() public view {
         assertEq(oracleMiddleware.getLowLatencyDelay(), DEFAULT_LOW_LATENCY_DELAY);
     }
 

--- a/test/unit/Middlewares/Oracle/SetPythRecentPriceDelay.t.sol
+++ b/test/unit/Middlewares/Oracle/SetPythRecentPriceDelay.t.sol
@@ -38,7 +38,7 @@ contract TestOracleMiddlewareSetPythRecentPriceDelay is OracleMiddlewareBaseFixt
      * @custom:when The result of the function is compared to 45
      * @custom:then It should succeed
      */
-    function test_recentPriceDelay() public {
+    function test_recentPriceDelay() public view {
         assertEq(oracleMiddleware.getPythRecentPriceDelay(), 45);
     }
 

--- a/test/unit/Middlewares/Oracle/SetRedstoneRecentPriceDelay.t.sol
+++ b/test/unit/Middlewares/Oracle/SetRedstoneRecentPriceDelay.t.sol
@@ -38,7 +38,7 @@ contract TestSetRedstoneRecentPriceDelay is OracleMiddlewareBaseFixture {
      * @custom:when The result of the function is compared to 45
      * @custom:then It should succeed
      */
-    function test_recentPriceDelay() public {
+    function test_recentPriceDelay() public view {
         assertEq(oracleMiddleware.getRedstoneRecentPriceDelay(), 45);
     }
 

--- a/test/unit/Middlewares/Oracle/UpdateChainlinkTimeElapsedLimit.t.sol
+++ b/test/unit/Middlewares/Oracle/UpdateChainlinkTimeElapsedLimit.t.sol
@@ -22,7 +22,7 @@ contract TestOracleMiddlewareUpdateChainlinkTimeElapsedLimit is OracleMiddleware
      * @custom:when The value returned by the function is compared to the value used in the ChainlinkOracle constructor.
      * @custom:then It should succeed.
      */
-    function test_chainlinkTimeElapsedLimit() public {
+    function test_chainlinkTimeElapsedLimit() public view {
         assertEq(oracleMiddleware.getChainlinkTimeElapsedLimit(), chainlinkTimeElapsedLimit);
     }
 

--- a/test/unit/Middlewares/Oracle/UpdateValidationDelay.t.sol
+++ b/test/unit/Middlewares/Oracle/UpdateValidationDelay.t.sol
@@ -16,7 +16,7 @@ contract TestOracleMiddlewareUpdateValidationDelay is OracleMiddlewareBaseFixtur
      * @custom:when The result of the result of the function is compared to 24
      * @custom:then It should succeed
      */
-    function test_validationDelay() public {
+    function test_validationDelay() public view {
         assertEq(oracleMiddleware.getValidationDelay(), 24 seconds);
     }
 

--- a/test/unit/Middlewares/Oracle/ValidationCost.t.sol
+++ b/test/unit/Middlewares/Oracle/ValidationCost.t.sol
@@ -37,7 +37,7 @@ contract TestOracleMiddlewareValidationCost is OracleMiddlewareBaseFixture {
      * @custom:when Data starts with the Pyth magic number
      * @custom:then The validation cost is the same as pythOracle
      */
-    function test_parseAndValidatePriceWithData() public {
+    function test_parseAndValidatePriceWithData() public view {
         uint256 fee = oracleMiddleware.validationCost(MOCK_PYTH_DATA, Types.ProtocolAction.None);
 
         assertEq(fee, mockPyth.getUpdateFee(data), "Wrong fee cost when data is a Pyth message");
@@ -48,7 +48,7 @@ contract TestOracleMiddlewareValidationCost is OracleMiddlewareBaseFixture {
      * @custom:when Data is empty
      * @custom:then The validation cost is the same as pythOracle
      */
-    function test_parseAndValidatePriceWithoutData() public {
+    function test_parseAndValidatePriceWithoutData() public view {
         uint256 fee = oracleMiddleware.validationCost("", Types.ProtocolAction.None);
 
         assertEq(fee, 0, "Fee should be 0 when there's no data");
@@ -59,7 +59,7 @@ contract TestOracleMiddlewareValidationCost is OracleMiddlewareBaseFixture {
      * @custom:when Data has no Pyth magic number
      * @custom:then The validation cost is 0
      */
-    function test_parseAndValidatePriceLowerThanLimit() public {
+    function test_parseAndValidatePriceLowerThanLimit() public view {
         uint256 fee = oracleMiddleware.validationCost(new bytes(48), Types.ProtocolAction.ValidateDeposit);
         assertEq(fee, 0, "Validation should be 0 when data does not contain magic");
     }

--- a/test/unit/Permit2TokenBitfield/Permit2TokenBitfield.t.sol
+++ b/test/unit/Permit2TokenBitfield/Permit2TokenBitfield.t.sol
@@ -20,7 +20,7 @@ contract TestPermit2TokenBitfield is Permit2TokenBitfieldFixture {
      * @custom:or The bitfield is 0b1111_1110
      * @custom:then The function should return false
      */
-    function test_asset() public {
+    function test_asset() public view {
         assertTrue(handler.useForAsset(Permit2TokenBitfield.Bitfield.wrap(1)), "0b0000_0001");
         assertTrue(handler.useForAsset(Permit2TokenBitfield.Bitfield.wrap(255)), "uint8.max");
         assertFalse(handler.useForAsset(Permit2TokenBitfield.Bitfield.wrap(0)), "0");
@@ -36,7 +36,7 @@ contract TestPermit2TokenBitfield is Permit2TokenBitfieldFixture {
      * @custom:or The bitfield is 0b1111_11101
      * @custom:then The function should return false
      */
-    function test_sdex() public {
+    function test_sdex() public view {
         assertTrue(handler.useForSdex(Permit2TokenBitfield.Bitfield.wrap(1 << 1)), "0b0000_0010");
         assertTrue(handler.useForSdex(Permit2TokenBitfield.Bitfield.wrap(255)), "uint8.max");
         assertFalse(handler.useForSdex(Permit2TokenBitfield.Bitfield.wrap(0)), "0");
@@ -52,7 +52,7 @@ contract TestPermit2TokenBitfield is Permit2TokenBitfieldFixture {
      * @custom:then The function should return false
      * @param bitfield The bitfield
      */
-    function testFuzz_asset(uint8 bitfield) public {
+    function testFuzz_asset(uint8 bitfield) public view {
         bool expectedResult = bitfield & 1 == 1;
         assertEq(handler.useForAsset(Permit2TokenBitfield.Bitfield.wrap(bitfield)), expectedResult);
     }
@@ -66,7 +66,7 @@ contract TestPermit2TokenBitfield is Permit2TokenBitfieldFixture {
      * @custom:then The function should return false
      * @param bitfield The bitfield
      */
-    function testFuzz_sdex(uint8 bitfield) public {
+    function testFuzz_sdex(uint8 bitfield) public view {
         bool expectedResult = bitfield >> 1 & 1 == 1;
         assertEq(handler.useForSdex(Permit2TokenBitfield.Bitfield.wrap(bitfield)), expectedResult);
     }

--- a/test/unit/Rebalancer/InitiateDepositAssets.t.sol
+++ b/test/unit/Rebalancer/InitiateDepositAssets.t.sol
@@ -23,7 +23,7 @@ contract TestRebalancerInitiateDepositAssets is RebalancerFixture {
      * @custom:when The setup was performed
      * @custom:then The initial deposit amount is greater than the minimum asset deposit
      */
-    function test_setUp() public {
+    function test_setUp() public view {
         assertGe(INITIAL_DEPOSIT, rebalancer.getMinAssetDeposit());
     }
 

--- a/test/unit/Rebalancer/InitiateWithdrawAssets.t.sol
+++ b/test/unit/Rebalancer/InitiateWithdrawAssets.t.sol
@@ -28,7 +28,7 @@ contract TestRebalancerInitiateWithdrawAssets is RebalancerFixture {
         initialPendingAssets = rebalancer.getPendingAssetsAmount();
     }
 
-    function test_setUp() public {
+    function test_setUp() public view {
         assertGe(INITIAL_DEPOSIT, rebalancer.getMinAssetDeposit());
     }
 

--- a/test/unit/Rebalancer/Rebalancer.t.sol
+++ b/test/unit/Rebalancer/Rebalancer.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.25;
 
-import { ADMIN } from "../../utils/Constants.sol";
 import { RebalancerFixture } from "./utils/Fixtures.sol";
 
 /**
@@ -49,7 +48,7 @@ contract TestRebalancer is RebalancerFixture {
      * @custom:when The getAsset function is called
      * @custom:then The value of the asset should be equal to the USDN protocol asset contract
      */
-    function test_asset() public {
+    function test_asset() public view {
         assertEq(address(usdnProtocol.getAsset()), address(rebalancer.getAsset()));
     }
 
@@ -59,7 +58,7 @@ contract TestRebalancer is RebalancerFixture {
      * @custom:when The getUsdnProtocol function is called
      * @custom:then The value of the _usdnProtocol should be equal to the protocol contract address
      */
-    function test_usdnProtocol() public {
+    function test_usdnProtocol() public view {
         assertEq(address(usdnProtocol), address(rebalancer.getUsdnProtocol()));
     }
 
@@ -69,7 +68,7 @@ contract TestRebalancer is RebalancerFixture {
      * @custom:when The getPositionVersion function is called
      * @custom:then The value of the _positionVersion should be equal to 0
      */
-    function test_positionVersion() public {
+    function test_positionVersion() public view {
         assertEq(0, rebalancer.getPositionVersion());
     }
 
@@ -79,7 +78,7 @@ contract TestRebalancer is RebalancerFixture {
      * @custom:when The getPositionMaxLeverage function is called
      * @custom:then The value of the _positionMaxLeverage should be equal to the USDN protocol's max leverage
      */
-    function test_getPositionMaxLeverage() public {
+    function test_getPositionMaxLeverage() public view {
         assertEq(rebalancer.getPositionMaxLeverage(), usdnProtocol.getMaxLeverage());
     }
 
@@ -113,7 +112,7 @@ contract TestRebalancer is RebalancerFixture {
      * @custom:when The getMinAssetDeposit function is called
      * @custom:then The value of the _minAssetDeposit should be equal to the protocol _minLongPosition
      */
-    function test_minAssetDeposit() public {
+    function test_minAssetDeposit() public view {
         assertEq(usdnProtocol.getMinLongPosition(), rebalancer.getMinAssetDeposit());
     }
 }

--- a/test/unit/Rebalancer/SupportsInterface.t.sol
+++ b/test/unit/Rebalancer/SupportsInterface.t.sol
@@ -24,7 +24,7 @@ contract TestRebalancerSupportsInterface is RebalancerFixture {
      * @custom:when The {supportsInterface} function is called with the interface IDs
      * @custom:then The function should return `true` for the supported interfaces and `false` for any other interface
      */
-    function test_supportsInterface() public {
+    function test_supportsInterface() public view {
         assertEq(rebalancer.supportsInterface(type(IERC165).interfaceId), true, "IERC165_ID supported");
         assertEq(
             rebalancer.supportsInterface(type(IOwnershipCallback).interfaceId), true, "IOwnershipCallback_ID supported"

--- a/test/unit/Rebalancer/ValidateWithdrawAssets.t.sol
+++ b/test/unit/Rebalancer/ValidateWithdrawAssets.t.sol
@@ -31,7 +31,7 @@ contract TestRebalancerValidateWithdrawAssets is RebalancerFixture {
         minAssetDeposit = uint88(rebalancer.getMinAssetDeposit());
     }
 
-    function test_setUp() public {
+    function test_setUp() public view {
         assertGe(INITIAL_DEPOSIT, rebalancer.getMinAssetDeposit());
     }
 

--- a/test/unit/SignedMath/Concrete.t.sol
+++ b/test/unit/SignedMath/Concrete.t.sol
@@ -20,7 +20,7 @@ contract TestSignedMathConcrete is SignedMathFixture {
      * @custom:when Calling `safeAdd`
      * @custom:then Return the sum of the operands
      */
-    function test_safeAdd() public {
+    function test_safeAdd() public view {
         assertEq(handler.safeAdd(42, 69), 111, "positive + positive");
         assertEq(handler.safeAdd(-42, 69), 27, "negative + positive");
         assertEq(handler.safeAdd(42, -69), -27, "positive + negative");
@@ -67,7 +67,7 @@ contract TestSignedMathConcrete is SignedMathFixture {
      * @custom:when Calling `safeSub`
      * @custom:then Return the difference of the operands
      */
-    function test_safeSub() public {
+    function test_safeSub() public view {
         assertEq(handler.safeSub(42, 69), -27, "positive - positive");
         assertEq(handler.safeSub(-42, 69), -111, "negative - positive");
         assertEq(handler.safeSub(42, -69), 111, "positive - negative");
@@ -114,7 +114,7 @@ contract TestSignedMathConcrete is SignedMathFixture {
      * @custom:when Calling `safeMul`
      * @custom:then Return the product of the operands
      */
-    function test_safeMul() public {
+    function test_safeMul() public view {
         assertEq(handler.safeMul(42, 69), 2898, "positive * positive");
         assertEq(handler.safeMul(-42, 69), -2898, "negative * positive");
         assertEq(handler.safeMul(-42, -69), 2898, "negative * negative");
@@ -175,7 +175,7 @@ contract TestSignedMathConcrete is SignedMathFixture {
      * @custom:when Calling `safeDiv`
      * @custom:then Return the quotient of the operands
      */
-    function test_safeDiv() public {
+    function test_safeDiv() public view {
         assertEq(handler.safeDiv(420, 69), 6, "positive / positive");
         assertEq(handler.safeDiv(-420, 69), -6, "negative / positive");
         assertEq(handler.safeDiv(420, -69), -6, "positive / negative");

--- a/test/unit/TickMath/Concrete.t.sol
+++ b/test/unit/TickMath/Concrete.t.sol
@@ -17,7 +17,7 @@ contract TestTickMathConcrete is TickMathFixture {
      * @custom:when The min and max usable ticks are retrieved
      * @custom:then The min usable tick is -320_000 and the max usable tick is 980_000
      */
-    function test_tickMinMax() public {
+    function test_tickMinMax() public view {
         int24 tickSpacing = 10_000;
         assertEq(handler.minUsableTick(tickSpacing), -320_000, "minUsableTick");
         assertEq(handler.maxUsableTick(tickSpacing), 980_000, "maxUsableTick");
@@ -29,7 +29,7 @@ contract TestTickMathConcrete is TickMathFixture {
      * @custom:when The min and max usable ticks are retrieved
      * @custom:then The min usable tick is -322_320 and the max usable tick is 979_980
      */
-    function test_tickMinMaxNegative() public {
+    function test_tickMinMaxNegative() public view {
         int24 tickSpacing = -60; // should never happen but we're safe here
         assertEq(handler.minUsableTick(tickSpacing), -322_320, "minUsableTick");
         assertEq(handler.maxUsableTick(tickSpacing), 979_980, "maxUsableTick");
@@ -41,7 +41,7 @@ contract TestTickMathConcrete is TickMathFixture {
      * @custom:when The price at the tick is retrieved
      * @custom:then The price is 990_050_328_741_209_514, 1.0001 ether +- 1 wei, or 1_010_049_662_092_876_534
      */
-    function test_tickToPrice() public {
+    function test_tickToPrice() public view {
         // Exact value according to WolframAlpha: 990_050_328_741_209_481
         assertEq(handler.getPriceAtTick(-100), 990_050_328_741_209_514, "price at tick -100");
         assertEq(handler.getPriceAtTick(0), 1 ether, "price at tick 0");
@@ -56,7 +56,7 @@ contract TestTickMathConcrete is TickMathFixture {
      * @custom:when The closest tick for the price is retrieved
      * @custom:then The closest tick is -1000, 0 or 1
      */
-    function test_priceToTick() public {
+    function test_priceToTick() public view {
         assertEq(handler.getClosestTickAtPrice(904_841_941_932_768_878), -1000, "at tick -1000");
         assertEq(handler.getClosestTickAtPrice(1 ether), 0, "at tick 0");
         assertEq(handler.getClosestTickAtPrice(1.0001 ether), 1, "at tick 1");

--- a/test/unit/TickMath/Constants.t.sol
+++ b/test/unit/TickMath/Constants.t.sol
@@ -13,7 +13,7 @@ contract TestTickMathConstants is TickMathFixture {
      * @custom:given The `LN_BASE` constant
      * @custom:then The `LN_BASE` constant is equal to the natural log of 1.0001
      */
-    function test_lnBase() public {
+    function test_lnBase() public pure {
         int256 base = 1.0001 ether;
         assertEq(FixedPointMathLib.lnWad(base), TickMath.LN_BASE);
     }
@@ -24,7 +24,7 @@ contract TestTickMathConstants is TickMathFixture {
      * @custom:then The `MIN_PRICE` constant is equal to the price corresponding to the `MIN_TICK` constant
      * @custom:and The `MIN_TICK` constant is equal to the tick corresponding to the `MIN_PRICE` constant
      */
-    function test_minPrice() public {
+    function test_minPrice() public view {
         uint256 minPrice = handler.getPriceAtTick(TickMath.MIN_TICK);
         assertEq(minPrice, TickMath.MIN_PRICE, "min price");
         int24 tick = handler.getClosestTickAtPrice(TickMath.MIN_PRICE);
@@ -37,7 +37,7 @@ contract TestTickMathConstants is TickMathFixture {
      * @custom:then The `MAX_PRICE` constant is equal to the price corresponding to the `MAX_TICK` constant
      * @custom:and The `MAX_TICK` constant is equal to the tick corresponding to the `MAX_PRICE` constant
      */
-    function test_maxPrice() public {
+    function test_maxPrice() public view {
         uint256 maxPrice = handler.getPriceAtTick(TickMath.MAX_TICK);
         assertEq(maxPrice, TickMath.MAX_PRICE, "max price");
         int24 tick = handler.getClosestTickAtPrice(TickMath.MAX_PRICE);

--- a/test/unit/TickMath/Fuzzing.t.sol
+++ b/test/unit/TickMath/Fuzzing.t.sol
@@ -23,7 +23,7 @@ contract TestTickMathFuzzing is TickMathFixture {
      * @custom:and The rounded down tick is within 1 tick of the original tick
      * @param tick The tick to convert to a price and back to a tick
      */
-    function testFuzz_conversion(int24 tick) public {
+    function testFuzz_conversion(int24 tick) public view {
         tick = bound_int24(tick, TickMath.MIN_TICK, TickMath.MAX_TICK);
         uint256 price = handler.getPriceAtTick(tick);
         console2.log("corresponding price", price);
@@ -43,7 +43,7 @@ contract TestTickMathFuzzing is TickMathFixture {
      * @custom:then The price is equal to the original price within 0.01%
      * @param price The price to convert to a tick and back to a price
      */
-    function testFuzz_conversionReverse(uint256 price) public {
+    function testFuzz_conversionReverse(uint256 price) public view {
         price = bound(price, TickMath.MIN_PRICE, TickMath.MAX_PRICE);
         int24 tick = handler.getClosestTickAtPrice(price);
         console2.log("corresponding tick", tick);

--- a/test/unit/USDN/ERC20.t.sol
+++ b/test/unit/USDN/ERC20.t.sol
@@ -22,7 +22,7 @@ contract TestUsdnErc20 is UsdnTokenFixture {
      * @custom:when The name is retrieved
      * @custom:then The name is equal to "Ultimate Synthetic Delta Neutral"
      */
-    function test_name() public {
+    function test_name() public view {
         assertEq(usdn.name(), "Ultimate Synthetic Delta Neutral");
     }
 
@@ -31,7 +31,7 @@ contract TestUsdnErc20 is UsdnTokenFixture {
      * @custom:when The symbol is retrieved
      * @custom:then The symbol is equal to "USDN"
      */
-    function test_symbol() public {
+    function test_symbol() public view {
         assertEq(usdn.symbol(), "USDN");
     }
 
@@ -40,7 +40,7 @@ contract TestUsdnErc20 is UsdnTokenFixture {
      * @custom:when The decimals are retrieved
      * @custom:then The decimals are equal to 18
      */
-    function test_decimals() public {
+    function test_decimals() public view {
         assertEq(usdn.decimals(), 18);
     }
 

--- a/test/unit/USDN/Invariants.t.sol
+++ b/test/unit/USDN/Invariants.t.sol
@@ -34,7 +34,7 @@ contract TestUsdnInvariants is UsdnTokenFixture {
     /**
      * @custom:scenario Check that the contract returns the expected number of shares for each user
      */
-    function invariant_shares() public displayBalancesAndShares {
+    function invariant_shares() public view displayBalancesAndShares {
         assertEq(usdn.sharesOf(USER_1), usdn.getSharesOfAddress(USER_1), "shares of user 1");
         assertEq(usdn.sharesOf(USER_2), usdn.getSharesOfAddress(USER_2), "shares of user 2");
         assertEq(usdn.sharesOf(USER_3), usdn.getSharesOfAddress(USER_3), "shares of user 3");
@@ -44,14 +44,14 @@ contract TestUsdnInvariants is UsdnTokenFixture {
     /**
      * @custom:scenario Check that the contract returns the expected number of total shares
      */
-    function invariant_totalShares() public displayBalancesAndShares {
+    function invariant_totalShares() public view displayBalancesAndShares {
         assertEq(usdn.totalShares(), usdn.totalSharesSum(), "total shares");
     }
 
     /**
      * @custom:scenario Check that the sum of the user shares is equal to the total shares
      */
-    function invariant_sumOfSharesBalances() public displayBalancesAndShares {
+    function invariant_sumOfSharesBalances() public view displayBalancesAndShares {
         uint256 sum;
         for (uint256 i = 0; i < usdn.getLengthOfShares(); i++) {
             (, uint256 value) = usdn.getElementOfIndex(i);
@@ -65,7 +65,7 @@ contract TestUsdnInvariants is UsdnTokenFixture {
      * @dev The sum of all user balances is not exactly equal to the total supply because of the rounding errors that
      * can stack up.
      */
-    function invariant_totalSupply() public displayBalancesAndShares {
+    function invariant_totalSupply() public view displayBalancesAndShares {
         uint256 sum;
         for (uint256 i = 0; i < usdn.getLengthOfShares(); i++) {
             (address user,) = usdn.getElementOfIndex(i);

--- a/test/unit/USDN/Permit.t.sol
+++ b/test/unit/USDN/Permit.t.sol
@@ -28,7 +28,7 @@ contract TestUsdnPermit is UsdnTokenFixture {
      * @custom:when The domain separator is retrieved
      * @custom:then The domain separator is equal to the expected value
      */
-    function test_domainSeparator() public {
+    function test_domainSeparator() public view {
         assertEq(usdn.DOMAIN_SEPARATOR(), hex"788006238c8d8eb7589a46d342d5e773630b340060ab348e6e4f155e72c651de");
     }
 

--- a/test/unit/USDN/Rebase.t.sol
+++ b/test/unit/USDN/Rebase.t.sol
@@ -26,7 +26,7 @@ contract TestUsdnRebase is UsdnTokenFixture {
      * @custom:when The `divisor` function is called
      * @custom:then The result is MAX_DIVISOR
      */
-    function test_getDivisor() public {
+    function test_getDivisor() public view {
         assertEq(usdn.divisor(), maxDivisor);
     }
 

--- a/test/unit/USDN/_ConvertToTokens.t.sol
+++ b/test/unit/USDN/_ConvertToTokens.t.sol
@@ -32,7 +32,7 @@ contract TestUsdnConvertToTokens is UsdnTokenFixture {
      * @custom:when We convert a random amount of shares to tokens rounding down
      * @custom:then The result is the integer quotient of shares divided by the divisor
      */
-    function testFuzz_convertToTokensDown(uint256 divisor, uint256 shares) public {
+    function testFuzz_convertToTokensDown(uint256 divisor, uint256 shares) public view {
         divisor = bound(divisor, usdn.MIN_DIVISOR(), usdn.MAX_DIVISOR());
 
         uint256 tokens = usdn.i_convertToTokens(shares, Usdn.Rounding.Down, divisor);
@@ -46,7 +46,7 @@ contract TestUsdnConvertToTokens is UsdnTokenFixture {
      * @custom:then The resulting amount of tokens is the result of dividing shares by the divisor and rounding up
      * @custom:but If the amount of corresponding shares would exceed uint256.max we round down
      */
-    function testFuzz_convertToTokensUp(uint256 divisor, uint256 shares) public {
+    function testFuzz_convertToTokensUp(uint256 divisor, uint256 shares) public view {
         divisor = bound(divisor, usdn.MIN_DIVISOR(), usdn.MAX_DIVISOR());
 
         uint256 tokens = usdn.i_convertToTokens(shares, Usdn.Rounding.Up, divisor);
@@ -67,7 +67,7 @@ contract TestUsdnConvertToTokens is UsdnTokenFixture {
      * closest integer
      * @custom:but If the amount of corresponding shares would exceed uint256.max we round down
      */
-    function testFuzz_convertToTokensClosest(uint256 divisor, uint256 shares) public {
+    function testFuzz_convertToTokensClosest(uint256 divisor, uint256 shares) public view {
         divisor = bound(divisor, usdn.MIN_DIVISOR(), usdn.MAX_DIVISOR());
 
         uint256 tokens = usdn.i_convertToTokens(shares, Usdn.Rounding.Closest, divisor);
@@ -92,7 +92,7 @@ contract TestUsdnConvertToTokens is UsdnTokenFixture {
      * @custom:then The resulting amount of tokens is the integer quotient of shares divided by the divisor, regardless
      * of the rounding mode
      */
-    function testFuzz_convertToTokensNoRemainder(uint256 divisor, uint256 multiple) public {
+    function testFuzz_convertToTokensNoRemainder(uint256 divisor, uint256 multiple) public view {
         divisor = bound(divisor, usdn.MIN_DIVISOR(), usdn.MAX_DIVISOR());
         multiple = bound(multiple, 0, type(uint256).max / divisor);
 

--- a/test/unit/UsdnProtocol/Actions/InitiateWithdrawal.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InitiateWithdrawal.t.sol
@@ -42,7 +42,7 @@ contract TestUsdnProtocolActionsInitiateWithdrawal is UsdnProtocolBaseFixture {
      * @custom:then The user's USDN balance is 2000 USDN
      * @custom:and The user's wstETH balance is 9 wstETH
      */
-    function test_withdrawSetUp() public {
+    function test_withdrawSetUp() public view {
         // Using the price computed with the default position fees
         assertEq(initialUsdnBalance, 2000 * DEPOSIT_AMOUNT, "initial usdn balance");
         assertEq(initialUsdnShares, 2000 * DEPOSIT_AMOUNT * usdn.MAX_DIVISOR(), "initial usdn shares");

--- a/test/unit/UsdnProtocol/Actions/SecurityDeposit.t.sol
+++ b/test/unit/UsdnProtocol/Actions/SecurityDeposit.t.sol
@@ -1123,7 +1123,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
     /*                                test helpers                                */
     /* -------------------------------------------------------------------------- */
 
-    function assertSecurityDepositPaid() public {
+    function assertSecurityDepositPaid() public view {
         assertEq(
             address(this).balance,
             balanceUser0Before - SECURITY_DEPOSIT_VALUE,
@@ -1136,7 +1136,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
     }
 
-    function assertSecurityDepositPaidDummyContract() public {
+    function assertSecurityDepositPaidDummyContract() public view {
         assertEq(
             address(this).balance,
             balanceUser0Before - SECURITY_DEPOSIT_VALUE,
@@ -1159,7 +1159,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
     }
 
-    function assertBalancesEnd() public {
+    function assertBalancesEnd() public view {
         assertEq(
             address(this).balance,
             balanceUser0Before,
@@ -1172,7 +1172,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
     }
 
-    function assertBalancesEndDummyContract() public {
+    function assertBalancesEndDummyContract() public view {
         assertEq(
             address(this).balance,
             balanceUser0Before - SECURITY_DEPOSIT_VALUE,
@@ -1195,7 +1195,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
     }
 
-    function assertBalancesEndTwoUsers() public {
+    function assertBalancesEndTwoUsers() public view {
         assertEq(
             address(this).balance,
             balanceUser0Before - SECURITY_DEPOSIT_VALUE,
@@ -1213,7 +1213,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
     }
 
-    function assertRefundEthToUser1() public {
+    function assertRefundEthToUser1() public view {
         assertEq(
             USER_1.balance,
             balanceUser1Before,
@@ -1231,7 +1231,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         );
     }
 
-    function assertSecurityDepositPaidTwoUsers() public {
+    function assertSecurityDepositPaidTwoUsers() public view {
         assertEq(
             USER_1.balance,
             balanceUser1Before - SECURITY_DEPOSIT_VALUE,
@@ -1264,6 +1264,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
 
     function _createPrevActionDataStruct(address user, bool assertValidatorContract)
         internal
+        view
         returns (PreviousActionsData memory prevActionsData_)
     {
         (PendingAction[] memory pendingAction, uint128[] memory rawIndices) = protocol.getActionablePendingActions(user);

--- a/test/unit/UsdnProtocol/Actions/ValidateWithdrawal.t.sol
+++ b/test/unit/UsdnProtocol/Actions/ValidateWithdrawal.t.sol
@@ -63,7 +63,7 @@ contract TestUsdnProtocolActionsValidateWithdrawal is UsdnProtocolBaseFixture {
      * @custom:then The user's USDN balance is 2000 USDN
      * @custom:and The user's wstETH balance is 9 wstETH
      */
-    function test_withdrawSetUp() public {
+    function test_withdrawSetUp() public view {
         // Using the price computed with the default position fees
         assertEq(initialUsdnBalance, 2000 * DEPOSIT_AMOUNT, "initial usdn balance");
         assertEq(initialUsdnShares, 2000 * DEPOSIT_AMOUNT * usdn.MAX_DIVISOR(), "initial usdn shares");

--- a/test/unit/UsdnProtocol/Actions/_AssetToRemove.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_AssetToRemove.t.sol
@@ -22,7 +22,7 @@ contract TestUsdnProtocolActionsAssetToRemove is UsdnProtocolBaseFixture {
      * @custom:then Asset to transfer and position value are equal
      * @custom:and The asset to transfer is slightly above 1.5 wstETH
      */
-    function test_assetToRemove() public {
+    function test_assetToRemove() public view {
         int24 tick = protocol.getEffectiveTickForPrice(params.initialPrice / 4);
         uint128 liqPrice = protocol.getEffectivePriceForTick(protocol.i_calcTickWithoutPenalty(tick));
         int256 value = protocol.i_positionValue(params.initialPrice, liqPrice, 2 ether);
@@ -41,7 +41,7 @@ contract TestUsdnProtocolActionsAssetToRemove is UsdnProtocolBaseFixture {
      * @custom:then Position value is greater than asset to transfer
      * @custom:and The asset to transfer is equal to the long available balance (because we don't have 150 wstETH)
      */
-    function test_assetToRemoveNotEnoughBalance() public {
+    function test_assetToRemoveNotEnoughBalance() public view {
         int24 tick = protocol.getEffectiveTickForPrice(params.initialPrice / 4);
         uint256 longAvailable = uint256(protocol.i_longAssetAvailable(params.initialPrice)); // 5 ether
         uint128 liqPrice = protocol.getEffectivePriceForTick(protocol.i_calcTickWithoutPenalty(tick));

--- a/test/unit/UsdnProtocol/Actions/_CheckInitiateClosePosition.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_CheckInitiateClosePosition.t.sol
@@ -35,7 +35,7 @@ contract TestUsdnProtocolCheckInitiateClosePosition is UsdnProtocolBaseFixture, 
         (pos,) = protocol.getLongPosition(posId);
     }
 
-    function test_setUpAmount() public {
+    function test_setUpAmount() public view {
         assertGt(protocol.getMinLongPosition(), 0, "min position");
         assertGt(AMOUNT, protocol.getMinLongPosition(), "position amount");
     }

--- a/test/unit/UsdnProtocol/Actions/_PrepareClosePositionData.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_PrepareClosePositionData.t.sol
@@ -113,7 +113,7 @@ contract TestUsdnProtocolActionsPrepareClosePositionData is UsdnProtocolBaseFixt
     }
 
     /// @notice Assert the data in ClosePositionData depending on `isEarlyReturn`
-    function _assertData(ClosePositionData memory data, bool isEarlyReturn) private {
+    function _assertData(ClosePositionData memory data, bool isEarlyReturn) private view {
         uint128 currentPrice = abi.decode(currentPriceData, (uint128));
         uint8 liquidationPenalty = protocol.getLiquidationPenalty();
         uint256 positionTotalExpo = protocol.i_calcPositionTotalExpo(

--- a/test/unit/UsdnProtocol/Actions/_PrepareInitiateDepositData.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_PrepareInitiateDepositData.t.sol
@@ -119,7 +119,7 @@ contract TestUsdnProtocolActionsPrepareInitiateDepositData is UsdnProtocolBaseFi
     }
 
     /// @notice Assert the data in InitiateDepositData depending on `isEarlyReturn`
-    function _assertData(ActionsVault.InitiateDepositData memory data, bool isEarlyReturn) private {
+    function _assertData(ActionsVault.InitiateDepositData memory data, bool isEarlyReturn) private view {
         uint128 currentPrice = abi.decode(currentPriceData, (uint128));
 
         if (isEarlyReturn) {

--- a/test/unit/UsdnProtocol/Actions/_PrepareValidateOpenPositionData.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_PrepareValidateOpenPositionData.t.sol
@@ -123,7 +123,7 @@ contract TestUsdnProtocolActionsPrepareValidateOpenPositionData is UsdnProtocolB
     }
 
     /// @notice Assert the data in ValidateOpenPositionData depending on `isEarlyReturn`
-    function _assertData(ValidateOpenPositionData memory data, bool isEarlyReturn) private {
+    function _assertData(ValidateOpenPositionData memory data, bool isEarlyReturn) private view {
         uint128 currentPrice = abi.decode(currentPriceData, (uint128));
         uint8 liquidationPenalty = protocol.getLiquidationPenalty();
         uint256 positionTotalExpo =

--- a/test/unit/UsdnProtocol/Actions/_PrepareWithdrawalData.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_PrepareWithdrawalData.t.sol
@@ -87,7 +87,7 @@ contract TestUsdnProtocolActionsPrepareWithdrawalData is UsdnProtocolBaseFixture
     }
 
     /// @notice Assert the data in WithdrawalData depending on `isEarlyReturn`
-    function _assertData(ActionsVault.WithdrawalData memory data, bool isEarlyReturn) private {
+    function _assertData(ActionsVault.WithdrawalData memory data, bool isEarlyReturn) private view {
         uint128 currentPrice = abi.decode(currentPriceData, (uint128));
 
         if (isEarlyReturn) {

--- a/test/unit/UsdnProtocol/FeeCollector/SupportsInterface.t.sol
+++ b/test/unit/UsdnProtocol/FeeCollector/SupportsInterface.t.sol
@@ -23,7 +23,7 @@ contract TestFeeCollectorSupportsInterface is UsdnProtocolBaseFixture {
      * @custom:then The function should return `true` for the supported interfaces and `false` for any other
      * interface
      */
-    function test_supportsInterfaceFeeCollector() public {
+    function test_supportsInterfaceFeeCollector() public view {
         assertEq(feeCollector.supportsInterface(type(IERC165).interfaceId), true, "IERC165_ID supported");
         assertEq(
             feeCollector.supportsInterface(type(IFeeCollectorCallback).interfaceId),

--- a/test/unit/UsdnProtocol/Long/GetEffectiveTickForPrice.t.sol
+++ b/test/unit/UsdnProtocol/Long/GetEffectiveTickForPrice.t.sol
@@ -23,7 +23,7 @@ contract TestUsdnProtocolLongGetEffectiveTickForPrice is UsdnProtocolBaseFixture
      * @custom:when getEffectiveTickForPrice is called
      * @custom:then The function should return expected minTick
      */
-    function testFuzz_getEffectiveTickForPriceExpectedMinTick(int24 tickSpacing) public {
+    function testFuzz_getEffectiveTickForPriceExpectedMinTick(int24 tickSpacing) public view {
         if (tickSpacing == 0) {
             return;
         }
@@ -48,7 +48,7 @@ contract TestUsdnProtocolLongGetEffectiveTickForPrice is UsdnProtocolBaseFixture
      * @custom:when getEffectiveTickForPrice is called with price 10_000
      * @custom:then The function should return tick_ = minTick
      */
-    function test_getEffectiveTickForPriceTickLowerThanZero() public {
+    function test_getEffectiveTickForPriceTickLowerThanZero() public view {
         /* ------------------------ minUsableTick < tick_ < 0 ----------------------- */
         int24 tickSpacing = 100;
         uint128 price = 60_000 ether;
@@ -83,7 +83,7 @@ contract TestUsdnProtocolLongGetEffectiveTickForPrice is UsdnProtocolBaseFixture
      * @custom:when getEffectiveTickForPrice is called with price 5_000_000_000 ether
      * @custom:then The function should return tick_ > 0
      */
-    function test_getEffectiveTickForPriceTickGreaterThanOrEqualZero() public {
+    function test_getEffectiveTickForPriceTickGreaterThanOrEqualZero() public view {
         /* -------------------------------- tick_ = 0 ------------------------------- */
         int24 tickSpacing = 100;
         uint128 price = 1 ether;

--- a/test/unit/UsdnProtocol/Long/_CalcBitmapIndexFromTick.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcBitmapIndexFromTick.t.sol
@@ -23,7 +23,7 @@ contract TestUsdnProtocolLongCalcBitmapIndexFromTick is UsdnProtocolBaseFixture 
      * @custom:when _calcBitmapIndexFromTick is called
      * @custom:then The index 0 is returned
      */
-    function test_calcBitmapIndexFromTickWithMinTick() public {
+    function test_calcBitmapIndexFromTickWithMinTick() public view {
         uint256 result = protocol.i_calcBitmapIndexFromTick(_minTick);
 
         assertEq(result, 0, "The result should be 0 (lowest possible index)");
@@ -35,7 +35,7 @@ contract TestUsdnProtocolLongCalcBitmapIndexFromTick is UsdnProtocolBaseFixture 
      * @custom:when _calcBitmapIndexFromTick is called
      * @custom:then The max index is returned
      */
-    function test_calcBitmapIndexFromTickWithMaxTick() public {
+    function test_calcBitmapIndexFromTickWithMaxTick() public view {
         uint256 maxIndex = uint256(int256(_maxTick - _minTick) / protocol.getTickSpacing());
         uint256 result = protocol.i_calcBitmapIndexFromTick(_maxTick);
 
@@ -53,7 +53,7 @@ contract TestUsdnProtocolLongCalcBitmapIndexFromTick is UsdnProtocolBaseFixture 
      * @param tick The tick corresponding to the bitmap index (multiple of the tick spacing)
      * @param tickSpacing The tick spacing to use for the calculations
      */
-    function testFuzz_calcBitmapIndexFromTick(int24 tick, int24 tickSpacing) public {
+    function testFuzz_calcBitmapIndexFromTick(int24 tick, int24 tickSpacing) public view {
         tickSpacing = int24(bound(tickSpacing, 1, 1000));
         // Bound the tick to values that are multiples of the tick spacing
         tick = int24(bound(tick, _minTick / tickSpacing, _maxTick / tickSpacing)) * tickSpacing;

--- a/test/unit/UsdnProtocol/Long/_CalcImbalanceCloseBps.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcImbalanceCloseBps.t.sol
@@ -19,7 +19,7 @@ contract TestUsdnProtocolLongCalcImbalanceCloseBps is UsdnProtocolBaseFixture {
      * @custom:then The imbalance is infinite
      * @custom:then int256.max is returned
      */
-    function test_calcImbalanceCloseBpsWith0TradingExpo() public {
+    function test_calcImbalanceCloseBpsWith0TradingExpo() public view {
         int256 vaultBalance = 200 ether;
         int256 longBalance = 0;
         uint256 totalExpo = 0;
@@ -38,7 +38,7 @@ contract TestUsdnProtocolLongCalcImbalanceCloseBps is UsdnProtocolBaseFixture {
      * @custom:or The total expo is 400 ether
      * @custom:then The imbalance is -33.33%
      */
-    function test_calcImbalanceCloseBps() public {
+    function test_calcImbalanceCloseBps() public view {
         int256 vaultBalance = 200 ether;
         int256 longBalance = 100 ether;
         uint256 totalExpo = 300 ether;
@@ -64,7 +64,7 @@ contract TestUsdnProtocolLongCalcImbalanceCloseBps is UsdnProtocolBaseFixture {
      * @param longBalance The long balance
      * @param totalExpo The total expo
      */
-    function testFuzz_calcImbalanceCloseBps(uint256 vaultBalance, uint256 longBalance, uint256 totalExpo) public {
+    function testFuzz_calcImbalanceCloseBps(uint256 vaultBalance, uint256 longBalance, uint256 totalExpo) public view {
         vaultBalance = bound(vaultBalance, 0, uint256(type(int256).max) / BPS_DIVISOR);
         longBalance = bound(longBalance, 0, uint256(type(int256).max) / BPS_DIVISOR - 1);
         totalExpo = bound(totalExpo, longBalance + 1, uint256(type(int256).max) / BPS_DIVISOR);

--- a/test/unit/UsdnProtocol/Long/_CalcImbalanceOpenBps.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcImbalanceOpenBps.t.sol
@@ -20,7 +20,7 @@ contract TestUsdnProtocolLongCalcImbalanceOpenBps is UsdnProtocolBaseFixture {
      * @custom:then The imbalance is infinite
      * @custom:and int256.max is returned
      */
-    function test_calcImbalanceOpenBpsWith0VaultBalance() public {
+    function test_calcImbalanceOpenBpsWith0VaultBalance() public view {
         int256 vaultBalance = 0;
         int256 longBalance = 100 ether;
         uint256 totalExpo = 200 ether;
@@ -39,7 +39,7 @@ contract TestUsdnProtocolLongCalcImbalanceOpenBps is UsdnProtocolBaseFixture {
      * @custom:when The vault balance is 300 ether
      * @custom:then The imbalance is -50%
      */
-    function test_calcImbalanceOpenBps() public {
+    function test_calcImbalanceOpenBps() public view {
         int256 vaultBalance = 200 ether;
         int256 longBalance = 100 ether;
         uint256 totalExpo = 300 ether;
@@ -65,7 +65,7 @@ contract TestUsdnProtocolLongCalcImbalanceOpenBps is UsdnProtocolBaseFixture {
      * @param longBalance The long balance
      * @param totalExpo The total expo
      */
-    function testFuzz_calcImbalanceOpenBps(uint256 vaultBalance, uint256 longBalance, uint256 totalExpo) public {
+    function testFuzz_calcImbalanceOpenBps(uint256 vaultBalance, uint256 longBalance, uint256 totalExpo) public view {
         vaultBalance = bound(vaultBalance, 1, uint256(type(int256).max) / BPS_DIVISOR);
         longBalance = bound(longBalance, 0, uint256(type(int256).max) / BPS_DIVISOR);
         totalExpo = bound(totalExpo, longBalance, uint256(type(int256).max) / BPS_DIVISOR);

--- a/test/unit/UsdnProtocol/Long/_CalcLiqPriceFromTradingExpo.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcLiqPriceFromTradingExpo.t.sol
@@ -27,7 +27,7 @@ contract TestUsdnProtocolLongCalcLiqPriceFromTradingExpo is UsdnProtocolBaseFixt
      * @custom:when {_calcLiqPriceFromTradingExpo} is called
      * @custom:then The returned liquidation price is correct
      */
-    function test_calcLiqPriceFromTradingExpo() public {
+    function test_calcLiqPriceFromTradingExpo() public view {
         uint128 amount = 2 ether;
         uint128 price = 2000 ether;
 
@@ -55,7 +55,7 @@ contract TestUsdnProtocolLongCalcLiqPriceFromTradingExpo is UsdnProtocolBaseFixt
      * @param price The current price of the asset
      * @param leverage The leverage to use
      */
-    function testFuzz_calcLiqPriceFromTradingExpo(uint256 amount, uint256 price, uint256 leverage) public {
+    function testFuzz_calcLiqPriceFromTradingExpo(uint256 amount, uint256 price, uint256 leverage) public view {
         amount = bound(amount, 1, type(uint128).max);
         price = bound(price, 1, type(uint128).max);
         leverage = bound(leverage, protocol.getMinLeverage(), protocol.getMaxLeverage());

--- a/test/unit/UsdnProtocol/Long/_CalcPositionTotalExpo.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcPositionTotalExpo.t.sol
@@ -74,7 +74,7 @@ contract TestUsdnProtocolLongCalcPositionTotalExpo is UsdnProtocolBaseFixture {
      * @custom:when The function `_calcPositionTotalExpo` is called with some parameters
      * @custom:then Expo is calculated correctly
      */
-    function test_calcPositionTotalExpo() public {
+    function test_calcPositionTotalExpo() public view {
         uint256 expo = protocol.i_calcPositionTotalExpo(1 ether, 2000 ether, 1500 ether);
         assertEq(expo, 4 ether, "Position total expo should be 4 ether");
 

--- a/test/unit/UsdnProtocol/Long/_CalcRebalancerPositionTick.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcRebalancerPositionTick.t.sol
@@ -23,7 +23,7 @@ contract TestUsdnProtocolLongCalcRebalancerPositionTick is UsdnProtocolBaseFixtu
      * @custom:when _calcRebalancerPositionTick is called
      * @custom:then The result is the expected tick
      */
-    function test_calcRebalancerPositionTick() public {
+    function test_calcRebalancerPositionTick() public view {
         uint256 maxLeverage = protocol.getMaxLeverage();
         uint256 totalExpo = 295 ether;
         uint256 missingTradingExpo = vaultBalance + longBalance - totalExpo;
@@ -57,7 +57,7 @@ contract TestUsdnProtocolLongCalcRebalancerPositionTick is UsdnProtocolBaseFixtu
      * @custom:when _calcRebalancerPositionTick is called with too much trading expo to fill
      * @custom:then The result has been capped to the protocol's max leverage
      */
-    function test_calcRebalancerPositionTickCappedByTheProtocolMaxLeverage() public {
+    function test_calcRebalancerPositionTickCappedByTheProtocolMaxLeverage() public view {
         uint256 rebalancerMaxLeverage = protocol.getMaxLeverage() + 1;
         uint256 totalExpo = 200 ether;
         uint128 amount = 1 ether;
@@ -93,7 +93,7 @@ contract TestUsdnProtocolLongCalcRebalancerPositionTick is UsdnProtocolBaseFixtu
      * @custom:when _calcRebalancerPositionTick is called with too little trading expo to fill
      * @custom:then The result is the expected tick capped to the protocol's min leverage
      */
-    function test_calcRebalancerPositionTickCappedByTheMinLeverage() public {
+    function test_calcRebalancerPositionTickCappedByTheMinLeverage() public view {
         uint256 rebalancerMaxLeverage = protocol.getMaxLeverage();
         uint256 totalExpo = vaultBalance + longBalance - 1;
         uint128 amount = 1 ether;
@@ -130,7 +130,7 @@ contract TestUsdnProtocolLongCalcRebalancerPositionTick is UsdnProtocolBaseFixtu
      * @custom:when _calcRebalancerPositionTick is called with too much trading expo to fill
      * @custom:then The result is the expected tick capped to the rebalancer max's leverage
      */
-    function test_calcRebalancerPositionTickCappedByTheRebalancerMaxLeverage() public {
+    function test_calcRebalancerPositionTickCappedByTheRebalancerMaxLeverage() public view {
         uint256 rebalancerMaxLeverage = protocol.getMaxLeverage() / 2;
         uint256 totalExpo = 200 ether;
         uint128 amount = 1 ether;
@@ -167,7 +167,7 @@ contract TestUsdnProtocolLongCalcRebalancerPositionTick is UsdnProtocolBaseFixtu
      * the protocol's min leverage
      * @custom:then The result is the expected tick capped by the protocol's min leverage
      */
-    function test_calcRebalancerPositionTickCappedByTheRebalancerMaxLeverageBelowTheMinLeverage() public {
+    function test_calcRebalancerPositionTickCappedByTheRebalancerMaxLeverageBelowTheMinLeverage() public view {
         uint256 rebalancerMaxLeverage = protocol.getMinLeverage() - 1;
         uint256 totalExpo = vaultBalance + longBalance - 1;
         uint128 amount = 1 ether;
@@ -202,7 +202,7 @@ contract TestUsdnProtocolLongCalcRebalancerPositionTick is UsdnProtocolBaseFixtu
      * @custom:when _calcRebalancerPositionTick is called with no trading expo to fill
      * @custom:then The result is NO_POSITION_TICK sentinel value
      */
-    function test_calcRebalancerPositionTickWithNoTradingExpoToFill() public {
+    function test_calcRebalancerPositionTickWithNoTradingExpoToFill() public view {
         uint256 rebalancerMaxLeverage = protocol.getMaxLeverage() + 1;
         uint256 totalExpo = vaultBalance + longBalance;
         uint128 amount = 1 ether;

--- a/test/unit/UsdnProtocol/Long/_CalcTickFromBitmapIndex.t.sol
+++ b/test/unit/UsdnProtocol/Long/_CalcTickFromBitmapIndex.t.sol
@@ -23,7 +23,7 @@ contract TestUsdnProtocolLongCalcTickFromBitmapIndex is UsdnProtocolBaseFixture 
      * @custom:when _calcTickFromBitmapIndex is called
      * @custom:then The minimum usable tick is returned
      */
-    function test_calcTickFromBitmapIndexWithMinIndex() public {
+    function test_calcTickFromBitmapIndexWithMinIndex() public view {
         int24 tick = protocol.i_calcTickFromBitmapIndex(0);
 
         assertEq(tick, _minTick, "The result should be the minimum usable tick");
@@ -35,7 +35,7 @@ contract TestUsdnProtocolLongCalcTickFromBitmapIndex is UsdnProtocolBaseFixture 
      * @custom:when _calcTickFromBitmapIndex is called
      * @custom:then The maximum usable tick is returned
      */
-    function test_calcTickFromBitmapIndexWithMaxIndex() public {
+    function test_calcTickFromBitmapIndexWithMaxIndex() public view {
         uint256 maxIndex = uint256(int256(_maxTick - _minTick) / protocol.getTickSpacing());
         int24 tick = protocol.i_calcTickFromBitmapIndex(maxIndex);
 
@@ -53,7 +53,7 @@ contract TestUsdnProtocolLongCalcTickFromBitmapIndex is UsdnProtocolBaseFixture 
      * @param index The index of the tick in the bitmap
      * @param tickSpacing The tick spacing to use for the calculations
      */
-    function testFuzz_calcTickFromBitmapIndex(uint256 index, int24 tickSpacing) public {
+    function testFuzz_calcTickFromBitmapIndex(uint256 index, int24 tickSpacing) public view {
         tickSpacing = int24(bound(tickSpacing, 1, 1000));
         // Bound the tick to values that are multiples of the tick spacing
         index = bound(index, 0, uint256((int256(_maxTick) - _minTick) / tickSpacing));

--- a/test/unit/UsdnProtocol/Long/_FindHighestPopulatedTick.t.sol
+++ b/test/unit/UsdnProtocol/Long/_FindHighestPopulatedTick.t.sol
@@ -56,7 +56,7 @@ contract TestUsdnProtocolLongFindHighestPopulatedTick is UsdnProtocolBaseFixture
      * @custom:when we call _findHighestPopulatedTick from a tick below its liquidation price
      * @custom:then the minimum usable tick is returned
      */
-    function test_findHighestPopulatedTickWhenNothingFound() public {
+    function test_findHighestPopulatedTickWhenNothingFound() public view {
         int24 result = protocol.i_findHighestPopulatedTick(_initialTick - protocol.getTickSpacing());
         assertEq(result, protocol.minTick(), "No tick should have been found (min usable tick returned)");
     }

--- a/test/unit/UsdnProtocol/Long/_GetLeverage.t.sol
+++ b/test/unit/UsdnProtocol/Long/_GetLeverage.t.sol
@@ -44,7 +44,7 @@ contract TestUsdnProtocolLongGetLeverage is UsdnProtocolBaseFixture {
      * @custom:when The function "_getLeverage" is called with some parameters
      * @custom:then The leverage is calculated correctly
      */
-    function test_getLeverageWithExpectedValue() public {
+    function test_getLeverageWithExpectedValue() public view {
         uint8 leverageDecimals = protocol.LEVERAGE_DECIMALS();
         uint256 leverage = protocol.i_getLeverage(1000, 1000 - 1);
         assertEq(leverage, 1000 * 10 ** leverageDecimals, "leverage should be 1000e21");

--- a/test/unit/UsdnProtocol/Long/_PositionValue.fuzzing.t.sol
+++ b/test/unit/UsdnProtocol/Long/_PositionValue.fuzzing.t.sol
@@ -34,6 +34,7 @@ contract TestUsdnProtocolFuzzingLong is UsdnProtocolBaseFixture {
      */
     function testFuzz_positionValue(uint128 amount, uint128 priceAtOpening, uint128 currentPrice, uint256 leverage)
         public
+        view
     {
         uint256 levDecimals = 10 ** protocol.LEVERAGE_DECIMALS();
         uint256 maxLeverage = protocol.getMaxLeverage();
@@ -79,7 +80,7 @@ contract TestUsdnProtocolFuzzingLong is UsdnProtocolBaseFixture {
         uint128 priceAtOpening,
         uint128 currentPrice,
         uint256 leverage
-    ) public {
+    ) public view {
         uint256 levDecimals = 10 ** protocol.LEVERAGE_DECIMALS();
         uint256 maxLeverage = protocol.getMaxLeverage();
 

--- a/test/unit/UsdnProtocol/Long/_PositionValue.t.sol
+++ b/test/unit/UsdnProtocol/Long/_PositionValue.t.sol
@@ -29,7 +29,7 @@ contract TestUsdnProtocolLongPositionValue is UsdnProtocolBaseFixture {
      * @custom:when the current price is $2000 and the leverage is 4x
      * @custom:then the position value is 2.5 wstETH
      */
-    function test_positionValue() public {
+    function test_positionValue() public view {
         uint128 positionTotalExpo = 2 ether;
         int256 value = protocol.i_positionValue(2000 ether, 500 ether, positionTotalExpo);
         assertEq(value, 1.5 ether, "Position value should be 1.5 ether");

--- a/test/unit/UsdnProtocol/Long/_TickValue.t.sol
+++ b/test/unit/UsdnProtocol/Long/_TickValue.t.sol
@@ -24,7 +24,7 @@ contract TestUsdnProtocolLongTickValue is UsdnProtocolBaseFixture {
      * @custom:or the tick value is 0.198003465594229687 wstETH if the price is equal to the liquidation price with
      * penalty
      */
-    function test_tickValue() public {
+    function test_tickValue() public view {
         int24 tick = protocol.getEffectiveTickForPrice(500 ether);
         uint128 liqPriceWithoutPenalty = protocol.getEffectivePriceForTick(protocol.i_calcTickWithoutPenalty(tick));
         TickData memory tickData =

--- a/test/unit/UsdnProtocol/Pending.t.sol
+++ b/test/unit/UsdnProtocol/Pending.t.sol
@@ -147,7 +147,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
      * @custom:when The actionable pending actions are requested
      * @custom:then No actionable pending action is returned
      */
-    function test_getActionablePendingActionEmpty() public {
+    function test_getActionablePendingActionEmpty() public view {
         (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0));
         assertEq(actions.length, 0, "empty list");
     }
@@ -301,7 +301,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
      * @custom:when The action is converted to a `DepositPendingAction` and back into a `PendingAction`
      * @custom:then The original and the converted `PendingAction` are equal
      */
-    function test_internalConvertDepositPendingAction() public {
+    function test_internalConvertDepositPendingAction() public view {
         PendingAction memory action = PendingAction({
             action: ProtocolAction.ValidateDeposit,
             timestamp: uint40(block.timestamp),
@@ -339,7 +339,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
      * @custom:when The action is converted to a `WithdrawalPendingAction` and back into a `PendingAction`
      * @custom:then The original and the converted `PendingAction` are equal
      */
-    function test_internalConvertWithdrawalPendingAction() public {
+    function test_internalConvertWithdrawalPendingAction() public view {
         PendingAction memory action = PendingAction({
             action: ProtocolAction.ValidateWithdrawal,
             timestamp: uint40(block.timestamp),
@@ -377,7 +377,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
      * @custom:when The action is converted to a `LongPendingAction` and back into a `PendingAction`
      * @custom:then The original and the converted `PendingAction` are equal
      */
-    function test_internalConvertLongPendingAction() public {
+    function test_internalConvertLongPendingAction() public view {
         PendingAction memory action = PendingAction({
             action: ProtocolAction.ValidateOpenPosition,
             timestamp: uint40(block.timestamp),

--- a/test/unit/UsdnProtocol/Rebase.t.sol
+++ b/test/unit/UsdnProtocol/Rebase.t.sol
@@ -43,7 +43,7 @@ contract TestUsdnProtocolRebase is UsdnProtocolBaseFixture, IUsdnEvents {
         uint128 assetPrice,
         uint128 targetPrice,
         uint8 assetDecimals
-    ) public {
+    ) public view {
         assetDecimals = uint8(bound(assetDecimals, 6, 18));
         // when the balance becomes really small, the error on the final price becomes larger
         vaultBalance = uint128(bound(vaultBalance, 10 ** assetDecimals, type(uint128).max));

--- a/test/unit/UsdnProtocol/Ticks.t.sol
+++ b/test/unit/UsdnProtocol/Ticks.t.sol
@@ -22,7 +22,7 @@ contract TestUsdnProtocolTicks is UsdnProtocolBaseFixture {
      * higher than the input price
      * @param price The price to convert to a tick
      */
-    function testFuzz_liqPrice(uint128 price) public {
+    function testFuzz_liqPrice(uint128 price) public view {
         price = uint128(bound(uint256(price), TickMath.MIN_PRICE, type(uint128).max));
         int24 closestTickDown = TickMath.getTickAtPrice(price);
         int24 tick = protocol.getEffectiveTickForPrice(price); // next valid tick towards infinity

--- a/test/unit/UsdnProtocol/Vault/PreviewWithdraw.t.sol
+++ b/test/unit/UsdnProtocol/Vault/PreviewWithdraw.t.sol
@@ -30,7 +30,7 @@ contract TestUsdnProtocolPreviewWithdraw is UsdnProtocolBaseFixture {
      * @custom:when The user simulates the withdrawal of half of the total shares of USDN
      * @custom:then The amount of asset should be equal to half of the available balance
      */
-    function test_previewWithdraw() public {
+    function test_previewWithdraw() public view {
         uint128 price = 2000 ether;
         uint128 priceWithFees = uint128(price + price * protocol.getVaultFeeBps() / protocol.BPS_DIVISOR());
         uint256 shares = usdn.totalShares() / 2;

--- a/test/unit/UsdnProtocol/Vault/Vault.t.sol
+++ b/test/unit/UsdnProtocol/Vault/Vault.t.sol
@@ -19,7 +19,7 @@ contract TestUsdnProtocolVault is UsdnProtocolBaseFixture {
      * @custom:then The original amount should be the same as the input
      * @param amount The amount to be split and merged
      */
-    function testFuzz_withdrawalAmountSplitting(uint152 amount) public {
+    function testFuzz_withdrawalAmountSplitting(uint152 amount) public view {
         uint24 lsb = protocol.i_calcWithdrawalAmountLSB(amount);
         uint128 msb = protocol.i_calcWithdrawalAmountMSB(amount);
         uint256 res = protocol.i_mergeWithdrawalAmountParts(lsb, msb);

--- a/test/unit/UsdnProtocol/Vault/_CalcBurnUsdn.t.sol
+++ b/test/unit/UsdnProtocol/Vault/_CalcBurnUsdn.t.sol
@@ -18,7 +18,7 @@ contract TestUsdnProtocolVaultCalcBurnUsdn is UsdnProtocolBaseFixture {
      * @custom:when The function "_calcBurnUsdn" is called with some parameters
      * @custom:then The asset amount is calculated correctly
      */
-    function test_calcBurnUsdn() public {
+    function test_calcBurnUsdn() public view {
         uint256 usdnShares = 10 ether;
         uint256 available = 10 ether;
         uint256 usdnTotalShares = 10 ether;

--- a/test/unit/UsdnProtocol/Vault/_CalcMintUsdnShares.t.sol
+++ b/test/unit/UsdnProtocol/Vault/_CalcMintUsdnShares.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.25;
 
-import { FixedPointMathLib } from "solady/src/utils/FixedPointMathLib.sol";
-
 import { UsdnProtocolBaseFixture } from "../utils/Fixtures.sol";
 
 /**

--- a/test/unit/UsdnProtocol/Vault/_CalcRebaseTotalSupply.t.sol
+++ b/test/unit/UsdnProtocol/Vault/_CalcRebaseTotalSupply.t.sol
@@ -17,7 +17,7 @@ contract TestUsdnProtocolVaultCalcRebaseTotalSupply is UsdnProtocolBaseFixture {
      * @custom:when The function "_calcRebaseTotalSupply" is called with some parameters
      * @custom:then The total supply is calculated correctly
      */
-    function test_calcRebaseTotalSupply() public {
+    function test_calcRebaseTotalSupply() public view {
         uint256 vaultBalance = 1000;
         uint128 assetPrice = 1000;
         uint128 targetPrice = 500;

--- a/test/unit/UsdnProtocol/Vault/_CalcSdexToBurn.t.sol
+++ b/test/unit/UsdnProtocol/Vault/_CalcSdexToBurn.t.sol
@@ -18,7 +18,7 @@ contract TestUsdnProtocolCalcUsdnPrice is UsdnProtocolBaseFixture {
      * @custom:when The function is called with this amount
      * @custom:then The correct amount of SDEX to burn is returned
      */
-    function test_calcSdexToBurn() public {
+    function test_calcSdexToBurn() public view {
         uint32 burnRatio = protocol.getSdexBurnOnDepositRatio();
         uint256 burnRatioDivisor = protocol.SDEX_BURN_ON_DEPOSIT_DIVISOR();
         uint8 usdnDecimals = protocol.TOKENS_DECIMALS();

--- a/test/unit/UsdnProtocol/Vault/_CalcUsdnPrice.t.sol
+++ b/test/unit/UsdnProtocol/Vault/_CalcUsdnPrice.t.sol
@@ -31,7 +31,7 @@ contract TestUsdnProtocolCalcUsdnPrice is UsdnProtocolBaseFixture {
      * @custom:when The total supply of USDN is 1M
      * @custom:then The price is $2
      */
-    function test_calcUsdnPrice() public {
+    function test_calcUsdnPrice() public view {
         uint8 assetDecimals = 6;
         // 1000 tokens in vault
         uint256 vaultBalance = 1000 * 10 ** assetDecimals;

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -327,7 +327,7 @@ contract UsdnProtocolBaseFixture is BaseFixture, IUsdnProtocolErrors, IEventsErr
      * @param b Second `PendingAction`
      * @param err Assert message prefix
      */
-    function _assertActionsEqual(PendingAction memory a, PendingAction memory b, string memory err) internal {
+    function _assertActionsEqual(PendingAction memory a, PendingAction memory b, string memory err) internal pure {
         assertTrue(a.action == b.action, string.concat(err, " - action type"));
         assertEq(a.timestamp, b.timestamp, string.concat(err, " - action timestamp"));
         assertEq(a.to, b.to, string.concat(err, " - action to"));

--- a/test/unit/WUSDN/Invariants.t.sol
+++ b/test/unit/WUSDN/Invariants.t.sol
@@ -44,7 +44,7 @@ contract TestWusdnInvariants is WusdnTokenFixture {
     /**
      * @custom:scenario Check that the contract has the expected number of total assets
      */
-    function invariant_totalAssetsSum() public {
+    function invariant_totalAssetsSum() public view {
         assertEq(usdn.balanceOf(address(wusdn)), wusdn.previewUnwrap(wusdn.totalSupply()), "total assets previewUnwrap");
         assertEq(usdn.sharesOf(address(wusdn)), wusdn.totalSupply() * wusdn.SHARES_RATIO(), "total shares");
     }
@@ -61,7 +61,7 @@ contract TestWusdnInvariants is WusdnTokenFixture {
     /**
      * @custom:scenario Check that the contract returns the expected number of tokens for each user
      */
-    function invariant_tokens() public {
+    function invariant_tokens() public view {
         assertEq(wusdn.balanceOf(USER_1), wusdn.getTokensOfAddress(USER_1), "balance of user 1");
         assertEq(wusdn.balanceOf(USER_2), wusdn.getTokensOfAddress(USER_2), "balance of user 2");
         assertEq(wusdn.balanceOf(USER_3), wusdn.getTokensOfAddress(USER_3), "balance of user 3");
@@ -71,7 +71,7 @@ contract TestWusdnInvariants is WusdnTokenFixture {
     /**
      * @custom:scenario Check that the sum of the user tokens is equal to the total tokens
      */
-    function invariant_sumOfTokensBalances() public {
+    function invariant_sumOfTokensBalances() public view {
         uint256 sum;
         for (uint256 i = 0; i < wusdn.getLengthOfTokens(); i++) {
             (, uint256 value) = wusdn.getElementOfIndex(i);
@@ -85,7 +85,7 @@ contract TestWusdnInvariants is WusdnTokenFixture {
      * @dev The sum of all user balances is not exactly equal to the total supply because of the rounding errors that
      * can stack up.
      */
-    function invariant_totalSupply() public {
+    function invariant_totalSupply() public view {
         uint256 sum;
         for (uint256 i = 0; i < wusdn.getLengthOfTokens(); i++) {
             (address user,) = wusdn.getElementOfIndex(i);

--- a/test/unit/WUSDN/utils/Handler.sol
+++ b/test/unit/WUSDN/utils/Handler.sol
@@ -105,10 +105,10 @@ contract WusdnHandler is Wusdn, Test {
         (, uint256 lastTokens) = _tokensHandle.tryGet(_actors[to]);
         _tokensHandle.set(_actors[to], lastTokens + wrappedAmount);
 
-        uint256 theoriticalShares = usdnShares / SHARES_RATIO * SHARES_RATIO;
+        uint256 theoreticalShares = usdnShares / SHARES_RATIO * SHARES_RATIO;
         assertEq(wrappedAmount, wrappedAmountPreview, "wrap : wrapped amount");
-        assertEq(totalUsdnShares + theoriticalShares, this.totalUsdnShares(), "wrap : total USDN shares in WUSDN");
-        assertEq(usdnSharesUser - theoriticalShares, _usdn.sharesOf(msg.sender), "wrap : USDN shares of the user");
+        assertEq(totalUsdnShares + theoreticalShares, this.totalUsdnShares(), "wrap : total USDN shares in WUSDN");
+        assertEq(usdnSharesUser - theoreticalShares, _usdn.sharesOf(msg.sender), "wrap : USDN shares of the user");
         assertEq(wusdnBalanceTo + wrappedAmount, balanceOf(_actors[to]), "wrap : WUSDN balance of the recipient");
     }
 
@@ -132,13 +132,13 @@ contract WusdnHandler is Wusdn, Test {
         _tokensHandle.set(msg.sender, lastTokens - wusdnAmount);
 
         assertEq(
-            totalUsdnShares - wusdnAmount * SHARES_RATIO, this.totalUsdnShares(), "uwwrap : total USDN shares in WUSDN"
+            totalUsdnShares - wusdnAmount * SHARES_RATIO, this.totalUsdnShares(), "unwrap : total USDN shares in WUSDN"
         );
-        assertEq(wusdnBalanceUser - wusdnAmount, balanceOf(msg.sender), "uwwrap : WUSDN balance of the user");
+        assertEq(wusdnBalanceUser - wusdnAmount, balanceOf(msg.sender), "unwrap : WUSDN balance of the user");
         assertEq(
             usdnSharesTo + wusdnAmount * SHARES_RATIO,
             _usdn.sharesOf(_actors[to]),
-            "uwwrap : USDN balance of the recipient"
+            "unwrap : USDN balance of the recipient"
         );
     }
 


### PR DESCRIPTION
Forge-std recently migrated to using native solidity asserts for their `assert...` functions, which means a lot of tests can be marked as being "view" or "pure".