### PR TITLE
build: ignore `too-many-warnings` error

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,13 @@ optimizer = true
 optimizer_runs = 20_000
 libs = ["node_modules", "lib"]
 invariant = { fail_on_revert = true }
+ignored_error_codes = [
+    "license",
+    "code-size",
+    "init-code-size",
+    "transient-storage",
+    "too-many-warnings",
+]
 
 # -------------------------------- Remappings -------------------------------- #
 


### PR DESCRIPTION
Since we have a lot of "code size" errors in the test contracts, and those get ignored by foundry, we get a warning 4591 that there are too many warnings to show them all. Since we don't care about those and we anyway see meaningful warnings, we can ignore warning 4591. I had to add the default configuration options as well (license, code-size etc) otherwise the default config would get overridden by the change.