### PR TITLE
fix(mock): set the timestamp at block.timestamp in the wsteth mock oracle middleware

### DIFF
--- a/src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol
+++ b/src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol
@@ -57,7 +57,7 @@ contract MockWstEthOracleMiddleware is WstEthOracleMiddleware {
         if (_verifySignature || _wstethMockedPrice == 0) {
             price_ = super.parseAndValidatePrice(actionId, targetTimestamp, action, data);
         } else {
-            price_.timestamp = targetTimestamp;
+            price_.timestamp = targetTimestamp == 0 ? block.timestamp : targetTimestamp;
         }
 
         // if the mocked price is not set, return


### PR DESCRIPTION
Right now, for a liquidation, the timestamp is 0 and we can never liquidate because the timestamp is always older than the lastTimestamp