### PR TITLE
fix(build): fix exportAbi script and package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cov:html": "npm run coverage && genhtml --ignore-errors corrupt,inconsistent -o .coverage lcov.info && open .coverage/index.html",
     "cov": "forge build --skip .sol && forge coverage --no-match-test \"(FFI|Fork|Fuzz|invariant)\" --no-match-contract Fork -vvv --offline",
     "coverage": "npm run cov -- --report lcov",
-    "exportAbi": "forge build --ast && ts-node ./script/exportAbi.ts -g '{Rebalancer/Rebalancer.sol,Usdn/Usdn.sol,Usdn/Wusdn.sol,UsdnProtocol/UsdnProtocol.sol,OracleMiddleware/LiquidationRewardsManager.sol,OracleMiddleware/OracleMiddleware.sol}' && tsup ./dist/abi/index.ts --format cjs --format esm --dts --sourcemap",
+    "exportAbi": "forge build --ast && ts-node ./script/exportAbi.ts -g 'interfaces/**/*.sol' && tsup ./dist/abi/index.ts --format cjs --format esm --dts --sourcemap",
     "format:js": "npx @biomejs/biome format . --write",
     "format": "forge fmt",
     "installDeps": "npm i && forge soldeer install",
@@ -26,11 +26,7 @@
     "test": "forge test -vvv"
   },
   "main": "dist/index.js",
-  "files": [
-    "dist",
-    "broadcast",
-    "docs"
-  ],
+  "files": ["dist", "broadcast", "docs"],
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@defi-wonderland/natspec-smells": "^1.1.4",

--- a/script/exportAbi.ts
+++ b/script/exportAbi.ts
@@ -11,11 +11,49 @@ type EnumMember = {
   name: string;
 };
 
-type EnumNode = {
+type Node = {
   nodeType: string;
+};
+
+type NonterminalNode = Node & {
+  nodes: (NonterminalNode | EnumNode)[];
+};
+
+type EnumNode = Node & {
   canonicalName: string;
   members: EnumMember[];
 };
+
+function isNonterminal(node: Node): node is NonterminalNode {
+  return node.nodeType === 'ContractDefinition'; // can add more types later if necessary
+}
+
+function isEnum(node: Node): node is EnumNode {
+  return node.nodeType === 'EnumDefinition';
+}
+
+function getEnums(parentNode: NonterminalNode) {
+  const enums: Map<string, string> = new Map();
+  for (const node of parentNode.nodes) {
+    if (isNonterminal(node)) {
+      const childrenEnums = getEnums(node);
+      for (const item of childrenEnums) {
+        enums.set(item[0], item[1]);
+      }
+    } else if (isEnum(node)) {
+      const members = node.members.map((member: EnumMember) => `  ${member.name}`);
+      enums.set(
+        node.canonicalName,
+        `export enum ${sanitizeEnumName(node.canonicalName)} {\n${members.join(',\n')}\n};\n`,
+      );
+    }
+  }
+  return enums;
+}
+
+function sanitizeEnumName(canonicalName: string) {
+  return canonicalName.replace('.', '');
+}
 
 const program = new Command();
 
@@ -81,19 +119,16 @@ for (const name of solFiles) {
 
 // Get all enums
 const outFiles = globSync('out/**/*.json', { withFileTypes: true });
-if (DEBUG) console.log('artifacts:', outFiles);
 
 const allEnums: Map<string, string> = new Map();
 for (const artifact of outFiles) {
   try {
+    if (DEBUG) console.log('processing file', artifact.fullpath());
     const file = readFileSync(artifact.fullpath());
-    const {
-      ast: { nodes },
-    } = JSON.parse(file.toString());
-    const enums = nodes.filter((node: EnumNode) => node.nodeType === 'EnumDefinition');
-    for (const enum_ of enums) {
-      const members = enum_.members.map((member: EnumMember) => `  ${member.name}`);
-      allEnums.set(enum_.canonicalName, `export enum ${enum_.canonicalName} {\n${members.join(',\n')}\n};\n`);
+    const { ast } = JSON.parse(file.toString());
+    const enums = getEnums(ast as NonterminalNode);
+    for (const item of enums) {
+      allEnums.set(item[0], item[1]);
     }
   } catch {
     console.log(`${artifact.fullpath()} does not exist`);


### PR DESCRIPTION
This is theoretically a breaking change, but it's more of a hotfix for v0.17.0.
We now export all interfaces instead of some contracts.
Enum generation has been fixed and is now recursive over the AST.