### PR TITLE
feat(oracle): let the middleware return the chainlink price if Pyth reverts for initiate actions

### DIFF
--- a/src/OracleMiddleware/oracles/PythOracle.sol
+++ b/src/OracleMiddleware/oracles/PythOracle.sol
@@ -168,7 +168,12 @@ abstract contract PythOracle is IPythOracle, IOracleMiddlewareErrors {
         returns (FormattedPythPrice memory price_)
     {
         // we use getPriceUnsafe to get the latest price without reverting, no matter how old
-        PythStructs.Price memory pythPrice = _pyth.getPriceUnsafe(_pythFeedId);
+        PythStructs.Price memory pythPrice;
+        // if the proxy implementation changes, this can revert
+        try _pyth.getPriceUnsafe(_pythFeedId) returns (PythStructs.Price memory unsafePrice_) {
+            pythPrice = unsafePrice_;
+        } catch { }
+
         // negative or zero prices are considered invalid, we return zero
         if (pythPrice.price <= 0) {
             return price_;

--- a/test/unit/Middlewares/Oracle/ParseAndValidatePrice.t.sol
+++ b/test/unit/Middlewares/Oracle/ParseAndValidatePrice.t.sol
@@ -139,6 +139,33 @@ contract TestOracleMiddlewareParseAndValidatePrice is OracleMiddlewareBaseFixtur
     }
 
     /**
+     * @custom:scenario Call to parseAndValidatePrice for "initiate" actions still works when Pyth reverts
+     * @custom:given Empty data is provided and calls to the Pyth oracle revert
+     * @custom:when Calling parseAndValidatePrice for "initiate" actions
+     * @custom:then It returns the onchain price from chainlink without reverting
+     */
+    function test_getPriceFromChainlinkWhenPythReverts() public {
+        mockPyth.toggleRevert();
+
+        mockChainlinkOnChain.setLatestRoundData(1, int256(ETH_PRICE), TARGET_TIMESTAMP, 1);
+
+        PriceInfo memory priceInfo = oracleMiddleware.parseAndValidatePrice("", 0, Types.ProtocolAction.Initialize, "");
+        assertEq(priceInfo.price, FORMATTED_ETH_PRICE);
+
+        priceInfo = oracleMiddleware.parseAndValidatePrice("", 0, Types.ProtocolAction.InitiateDeposit, "");
+        assertEq(priceInfo.price, FORMATTED_ETH_PRICE);
+
+        priceInfo = oracleMiddleware.parseAndValidatePrice("", 0, Types.ProtocolAction.InitiateWithdrawal, "");
+        assertEq(priceInfo.price, FORMATTED_ETH_PRICE);
+
+        priceInfo = oracleMiddleware.parseAndValidatePrice("", 0, Types.ProtocolAction.InitiateOpenPosition, "");
+        assertEq(priceInfo.price, FORMATTED_ETH_PRICE);
+
+        priceInfo = oracleMiddleware.parseAndValidatePrice("", 0, Types.ProtocolAction.InitiateClosePosition, "");
+        assertEq(priceInfo.price, FORMATTED_ETH_PRICE);
+    }
+
+    /**
      * @custom:scenario Parse and validate price for "validate" actions using chainlink with a roundId data
      * @custom:given The chainlink validate roundId data
      * @custom:and A correct chainlink previous roundId

--- a/test/unit/Middlewares/utils/MockPyth.sol
+++ b/test/unit/Middlewares/utils/MockPyth.sol
@@ -121,7 +121,9 @@ contract MockPyth is IMockPythError {
     }
 
     /// @dev Simulate an invalid price so that the cached price is never used in testing
-    function getPriceUnsafe(bytes32) public pure returns (PythStructs.Price memory price_) {
+    function getPriceUnsafe(bytes32) public view returns (PythStructs.Price memory price_) {
+        if (alwaysRevertOnCall) revert MockedPythError();
+
         price_.price = -1;
     }
 }


### PR DESCRIPTION
Add a try/catch block to Pyth's `getPriceUnsafe` call for initiate actions with empty data.
So if the Proxy implementation of Pyth changes, users can still initiate actions using Chainlink.