### PR TITLE
ci: roll our own trufflehog job

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -43,7 +43,7 @@ jobs:
           git file:///tmp/ \
           --since-commit \
           $BASE \
-          --branch HEAD \
+          --branch main \
           --fail \
           --no-update \
           --github-actions \
@@ -58,7 +58,7 @@ jobs:
           git file:///tmp/ \
           --since-commit \
           ${{ github.event.pull_request.base.sha }} \
-          --branch HEAD \
+          --branch ${{ github.event.pull_request.head.ref }} \
           --fail \
           --no-update \
           --github-actions \


### PR DESCRIPTION
The default parameters of the trufflehog action are not optimal for our use case, and there might be a bug with the `--branch` argument involved (when a commit hash is passed into it). In any case, handling the command arguments ourselves might be better.