### PR TITLE
fix(rebalancer-trigger): only gift the previous position value when dealing with dust

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolLongLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolLongLibrary.sol
@@ -499,7 +499,7 @@ library UsdnProtocolLongLibrary {
             // make the rebalancer believe that the previous position was liquidated,
             // and inform it that no new position was open so it can start anew
             rebalancer.updatePosition(Types.PositionId(Constants.NO_POSITION_TICK, 0, 0), 0);
-            vaultBalance_ += data.positionAmount;
+            vaultBalance_ += data.positionValue;
             return (longBalance_, vaultBalance_);
         }
 


### PR DESCRIPTION
Found by the audit.

As we do not transfer the pending assets, we should only gift the previous position value to the vault.
Even though the pending assets can only be 0 and the data.positionAmount variable only contain the dust, as the rebalancer can be changed, this is safer.