### PR TITLE
refactor(middleware): better casting route between i64 and uint256

### DIFF
--- a/src/OracleMiddleware/oracles/PythOracle.sol
+++ b/src/OracleMiddleware/oracles/PythOracle.sol
@@ -139,7 +139,7 @@ abstract contract PythOracle is IPythOracle, IOracleMiddlewareErrors {
         uint256 pythDecimals = uint32(-pythPrice.expo);
 
         price_ = FormattedPythPrice({
-            price: uint256(uint64(pythPrice.price)) * 10 ** middlewareDecimals / 10 ** pythDecimals,
+            price: uint256(int256(pythPrice.price)) * 10 ** middlewareDecimals / 10 ** pythDecimals,
             conf: uint256(pythPrice.conf) * 10 ** middlewareDecimals / 10 ** pythDecimals,
             publishTime: pythPrice.publishTime
         });


### PR DESCRIPTION
The previous implementation was casting int64 to uint64 before casting to uint256. In principle, it's better to first cast to int256 and then uint256, as that would allow it to work even if pyth someday decides to return a larger type without warning us. This was changed out of an abundance of caution.