### PR TITLE
docs: fix mentions of wstETH

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
@@ -318,8 +318,8 @@ library UsdnProtocolActionsUtilsLibrary {
     }
 
     /**
-     * @notice Calculate how much wstETH must be removed from the long balance due to a position closing
-     * @dev The amount is bound by the amount of wstETH available on the long side
+     * @notice Calculate how much assets must be removed from the long balance due to a position closing
+     * @dev The amount is bound by the amount of assets available on the long side
      * @param balanceLong The balance of long positions (with asset decimals)
      * @param price The price to use for the position value calculation
      * @param liqPriceWithoutPenalty The liquidation price without penalty

--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsVaultLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsVaultLibrary.sol
@@ -399,7 +399,7 @@ library UsdnProtocolActionsVaultLibrary {
      * @param user The address of the user initiating the deposit
      * @param to The address to receive the USDN tokens
      * @param validator The address that will validate the deposit
-     * @param amount The amount of wstETH to deposit
+     * @param amount The amount of assets to deposit
      * @param securityDepositValue The value of the security deposit for the newly created pending action
      * @param permit2TokenBitfield The permit2 bitfield
      * @param currentPriceData The current price data

--- a/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
@@ -115,7 +115,7 @@ library UsdnProtocolCoreLibrary {
      * @param price The current asset price
      */
     function _createInitialDeposit(Types.Storage storage s, uint128 amount, uint128 price) public {
-        // transfer the wstETH for the deposit
+        // transfer the assets for the deposit
         address(s._asset).safeTransferFrom(msg.sender, address(this), amount);
         s._balanceVault += amount;
         emit IUsdnProtocolEvents.InitiatedDeposit(msg.sender, msg.sender, amount, 0, block.timestamp, 0);
@@ -159,7 +159,7 @@ library UsdnProtocolCoreLibrary {
         int24 tick,
         uint128 totalExpo
     ) public {
-        // transfer the wstETH for the long
+        // transfer the assets for the long
         address(s._asset).safeTransferFrom(msg.sender, address(this), amount);
 
         Types.PositionId memory posId;

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
@@ -13,7 +13,7 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * of the middleware
      * The transaction must have `_securityDepositValue` in value
      * In case liquidations are pending, this function might not initiate the deposit (and `success_` would be false)
-     * @param amount The amount of wstETH to deposit
+     * @param amount The amount of assets to deposit
      * @param to The address that will receive the USDN tokens
      * @param validator The address that will validate the deposit
      * @param permit2TokenBitfield Whether to use permit2 for transferring assets (first bit) and SDEX (second bit)
@@ -112,7 +112,7 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * leverage). The validation operation then updates the entry price and leverage with fresher data
      * The transaction must have `_securityDepositValue` in value
      * In case liquidations are pending, this function might not initiate the position (and `success_` would be false)
-     * @param amount The amount of wstETH to deposit
+     * @param amount The amount of assets to deposit
      * @param desiredLiqPrice The desired liquidation price, including the liquidation penalty
      * @param userMaxLeverage The maximum leverage for the newly created position
      * @param to The address that will be the owner of the position

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolCore.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolCore.sol
@@ -57,8 +57,8 @@ interface IUsdnProtocolCore is IUsdnProtocolTypes {
      * `ProtocolAction.Initialize` action
      * The price validation might require payment according to the return value of the `getValidationCost` function
      * of `IBaseOracleMiddleware`
-     * @param depositAmount The amount of wstETH for the deposit
-     * @param longAmount The amount of wstETH for the long
+     * @param depositAmount The amount of assets for the deposit
+     * @param longAmount The amount of assets for the long
      * @param desiredLiqPrice The desired liquidation price for the long, without penalty
      * @param currentPriceData The current price data
      */

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolFallback.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolFallback.sol
@@ -149,8 +149,8 @@ interface IUsdnProtocolFallback {
     function NO_POSITION_TICK() external view returns (int24);
 
     /**
-     * @notice Get the minimum amount of wstETH for the initialization deposit and long
-     * @return The minimum amount of wstETH
+     * @notice Get the minimum amount of assets for the initialization deposit and long
+     * @return The minimum amount of assets
      */
     function MIN_INIT_DEPOSIT() external view returns (uint256);
 

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolImpl.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolImpl.sol
@@ -30,7 +30,7 @@ interface IUsdnProtocolImpl is
      * It can only be called once
      * @param usdn The USDN ERC20 contract
      * @param sdex The SDEX ERC20 contract
-     * @param asset The asset ERC20 contract (wstETH)
+     * @param asset The asset ERC20 contract
      * @param oracleMiddleware The oracle middleware contract
      * @param liquidationRewardsManager The liquidation rewards manager contract
      * @param tickSpacing The positions tick spacing

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol
@@ -254,7 +254,7 @@ interface IUsdnProtocolTypes {
      * @param user The address of the user initiating the open position
      * @param to The address that will be the owner of the position
      * @param validator The address that will validate the open position
-     * @param amount The amount of wstETH to deposit
+     * @param amount The amount of assets to deposit
      * @param desiredLiqPrice The desired liquidation price, including the liquidation penalty
      * @param userMaxLeverage The maximum leverage for the newly created position
      * @param securityDepositValue The value of the security deposit for the newly created pending action
@@ -276,7 +276,7 @@ interface IUsdnProtocolTypes {
     /**
      * @notice Parameters for the internal `_prepareInitiateOpenPosition` function
      * @param validator The address of the validator
-     * @param amount The amount of wstETH to deposit
+     * @param amount The amount of assets to deposit
      * @param desiredLiqPrice The desired liquidation price, including the liquidation penalty
      * @param userMaxLeverage The maximum leverage for the newly created position
      * @param currentPriceData The current price data
@@ -475,9 +475,9 @@ interface IUsdnProtocolTypes {
      * @param _tickSpacing The liquidation tick spacing for storing long positions
      * A tick spacing of 1 is equivalent to a 0.01% increase in liquidation price between ticks. A tick spacing of
      * 100 is equivalent to a ~1.005% increase in liquidation price between ticks
-     * @param _asset The asset ERC20 contract (wstETH)
-     * @param _assetDecimals The asset decimals (wstETH => 18)
-     * @param _priceFeedDecimals The price feed decimals (wstETH => 18)
+     * @param _asset The asset ERC20 contract
+     * @param _assetDecimals The asset decimals
+     * @param _priceFeedDecimals The price feed decimals (18)
      * @param _usdn The USDN ERC20 contract
      * @param _sdex The SDEX ERC20 contract
      * @param _usdnMinDivisor The minimum divisor for USDN


### PR DESCRIPTION
The asset token does not need to be wstETH. Natspec comments should reflect that and stay agnostic of the underlying token.