### PR TITLE
fix(slither): ignore slither arbitrary-send-eth error in permissioned function

### DIFF
--- a/src/OracleMiddleware/OracleMiddleware.sol
+++ b/src/OracleMiddleware/OracleMiddleware.sol
@@ -444,6 +444,7 @@ contract OracleMiddleware is
             revert OracleMiddlewareTransferToZeroAddress();
         }
 
+        // slither-disable-next-line arbitrary-send-eth
         (bool success,) = payable(to).call{ value: address(this).balance }("");
         if (!success) {
             revert OracleMiddlewareTransferFailed(to);


### PR DESCRIPTION
Ignores a slither error in the permissioned function that withdraw ether in the oracle middleware contract as it will only send ether to an address the admin specified.