### PR TITLE
fix: close imbalance check

### DIFF
--- a/test/unit/UsdnProtocol/Actions/_ImbalanceLimitClose.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ImbalanceLimitClose.t.sol
@@ -28,7 +28,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
      */
     function test_checkImbalanceLimitClose() public view {
         (, uint256 longAmount, uint256 totalExpoValueToLimit) = _getCloseLimitValues(false);
-        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit / 2, longAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit / 2, longAmount);
     }
 
     /**
@@ -40,7 +40,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
      */
     function test_checkImbalanceLimitCloseOnLimit() public view {
         (, uint256 longAmount, uint256 totalExpoValueToLimit) = _getCloseLimitValues(false);
-        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit - 1, longAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit - 1, longAmount);
     }
 
     /**
@@ -55,7 +55,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
         vm.expectRevert(
             abi.encodeWithSelector(IUsdnProtocolErrors.UsdnProtocolImbalanceLimitReached.selector, closeLimitBps)
         );
-        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit, longAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit, longAmount);
     }
 
     /**
@@ -75,7 +75,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
             abi.encodeWithSelector(IUsdnProtocolErrors.UsdnProtocolImbalanceLimitReached.selector, closeLimitBps)
         );
 
-        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit, longAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit, longAmount);
     }
 
     /**
@@ -90,7 +90,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
         // disable close limit
         protocol.setExpoImbalanceLimits(200, 200, 600, 0, 0, 0);
 
-        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit + 1, longAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit + 1, longAmount);
     }
 
     /**
@@ -149,7 +149,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
         vm.expectRevert(
             abi.encodeWithSelector(IUsdnProtocolErrors.UsdnProtocolImbalanceLimitReached.selector, type(int256).max)
         );
-        protocol.i_checkImbalanceLimitClose(0, 0, 0);
+        protocol.i_checkImbalanceLimitClose(0, 0);
     }
 
     /**
@@ -174,7 +174,7 @@ contract TestImbalanceLimitClose is UsdnProtocolBaseFixture {
                 IUsdnProtocolErrors.UsdnProtocolImbalanceLimitReached.selector, uint256(expectedImbalance)
             )
         );
-        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit, longAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoValueToLimit, longAmount);
     }
 
     /**

--- a/test/unit/UsdnProtocol/Actions/fuzzing/_ImbalanceLimitClose.fuzzing.t.sol
+++ b/test/unit/UsdnProtocol/Actions/fuzzing/_ImbalanceLimitClose.fuzzing.t.sol
@@ -54,6 +54,6 @@ contract TestImbalanceLimitCloseFuzzing is UsdnProtocolBaseFixture {
             );
         }
 
-        protocol.i_checkImbalanceLimitClose(totalExpoToRemove, closeAmount, 0);
+        protocol.i_checkImbalanceLimitClose(totalExpoToRemove, closeAmount);
     }
 }

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -404,11 +404,8 @@ contract UsdnProtocolHandler is UsdnProtocolImpl, Test {
         Long._checkImbalanceLimitOpen(s, openTotalExpoValue, openCollatValue);
     }
 
-    function i_checkImbalanceLimitClose(uint256 posTotalExpoToClose, uint256 posValueToClose, uint256 fees)
-        external
-        view
-    {
-        ActionsUtils._checkImbalanceLimitClose(s, posTotalExpoToClose, posValueToClose, fees);
+    function i_checkImbalanceLimitClose(uint256 posTotalExpoToClose, uint256 posValueToClose) external view {
+        ActionsUtils._checkImbalanceLimitClose(s, posTotalExpoToClose, posValueToClose);
     }
 
     function i_getLeverage(uint128 price, uint128 liqPrice) external pure returns (uint256) {

--- a/test/utils/IUsdnProtocolHandler.sol
+++ b/test/utils/IUsdnProtocolHandler.sol
@@ -202,9 +202,7 @@ interface IUsdnProtocolHandler is IUsdnProtocol {
 
     function i_checkImbalanceLimitOpen(uint256 openTotalExpoValue, uint256 openCollatValue) external view;
 
-    function i_checkImbalanceLimitClose(uint256 posTotalExpoToClose, uint256 posValueToCloseAfterFees, uint256 fees)
-        external
-        view;
+    function i_checkImbalanceLimitClose(uint256 posTotalExpoToClose, uint256 posValueToClose) external view;
 
     function i_getLeverage(uint128 price, uint128 liqPrice) external pure returns (uint256);
 


### PR DESCRIPTION
The position value that was used for the imbalance calculation on close was wrong. With these new values, the actual state that would result from the `initiateClosePosition` is used. The fee is ignored as it doesn't get added to the vault balance until the validation is performed.

Closes RA2BL-48