### PR TITLE
fix(rebalancer): prevent a rebalancer trigger during a rebalancer initiateClosePosition call

### DIFF
--- a/src/Rebalancer/Rebalancer.sol
+++ b/src/Rebalancer/Rebalancer.sol
@@ -526,7 +526,11 @@ contract Rebalancer is Ownable2Step, ReentrancyGuard, ERC165, IOwnershipCallback
     }
 
     /// @inheritdoc IBaseRebalancer
-    function updatePosition(Types.PositionId calldata newPosId, uint128 previousPosValue) external onlyProtocol {
+    function updatePosition(Types.PositionId calldata newPosId, uint128 previousPosValue)
+        external
+        onlyProtocol
+        nonReentrant
+    {
         uint128 positionVersion = _positionVersion;
         PositionData memory previousPositionData = _positionData[positionVersion];
         // set the multiplier accumulator to 1 by default

--- a/test/integration/UsdnProtocol/RebalancerTrigger.t.sol
+++ b/test/integration/UsdnProtocol/RebalancerTrigger.t.sol
@@ -111,7 +111,7 @@ contract TestUsdnProtocolRebalancerTrigger is UsdnProtocolBaseIntegrationFixture
 
         uint256 oracleFee = oracleMiddleware.validationCost(MOCK_PYTH_DATA, ProtocolAction.Liquidation);
 
-        data.liqRewards = calcRewards(int256(uint256(data.remainingCollateral)), wstEthPrice);
+        data.liqRewards = _calcRewards(int256(uint256(data.remainingCollateral)), wstEthPrice);
 
         _expectEmits(wstEthPrice, amountInRebalancer, data.bonus, liqPriceWithoutPenalty, expectedTick, 1);
         protocol.liquidate{ value: oracleFee }(MOCK_PYTH_DATA);
@@ -225,7 +225,7 @@ contract TestUsdnProtocolRebalancerTrigger is UsdnProtocolBaseIntegrationFixture
      * @param remainingCollateral The remaining collateral after the liquidation
      * @param wstEthPrice The price of the asset
      */
-    function calcRewards(int256 remainingCollateral, uint128 wstEthPrice) public view returns (uint256 rewards_) {
+    function _calcRewards(int256 remainingCollateral, uint128 wstEthPrice) internal view returns (uint256 rewards_) {
         uint256 tradingExpoWithFunding = protocol.longTradingExpoWithFunding(wstEthPrice, uint40(block.timestamp));
         uint128 tickPrice = protocol.getEffectivePriceForTick(
             posToLiquidate.tick, wstEthPrice, tradingExpoWithFunding, protocol.getLiqMultiplierAccumulator()

--- a/test/integration/UsdnProtocol/utils/Fixtures.sol
+++ b/test/integration/UsdnProtocol/utils/Fixtures.sol
@@ -346,7 +346,17 @@ contract UsdnProtocolBaseIntegrationFixture is BaseFixture, IUsdnProtocolErrors,
         );
     }
 
-    // @dev this function aims to persist the contracts when use vm.rollFork in tests
+    /// @dev Set the provided price and current timestamp in all of the mock oracles
+    function _setOraclePrices(uint128 wstEthPrice) internal {
+        uint128 ethPrice = uint128(wstETH.getWstETHByStETH(wstEthPrice)) / 1e10;
+        mockPyth.setPrice(int64(uint64(ethPrice)));
+        mockPyth.setLastPublishTime(block.timestamp);
+        wstEthPrice = uint128(wstETH.getStETHByWstETH(ethPrice * 1e10));
+        mockChainlinkOnChain.setLastPublishTime(block.timestamp);
+        mockChainlinkOnChain.setLastPrice(int256(uint256(ethPrice)));
+    }
+
+    /// @dev this function aims to persist the contracts when use vm.rollFork in tests
     function persistContracts() internal {
         vm.makePersistent(address(protocol));
         vm.makePersistent(address(implementation));


### PR DESCRIPTION
This PR fixes the rebalancer triggering itself during a rebalancer `initiateClosePosition`'s call that would mess up the storage.
Adding a reentrancy check to the `updatePosition` function fixes that.
I also added a test to avoid regressions.

Closes RA2BL-109