### PR TITLE
fix(deposit): add the vault fee to the vault balance to calculate the amount of shares to mint

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolFallback.sol
+++ b/src/UsdnProtocol/UsdnProtocolFallback.sol
@@ -49,8 +49,9 @@ contract UsdnProtocolFallback is IUsdnProtocolFallback, UsdnProtocolStorage {
             revert IUsdnProtocolErrors.UsdnProtocolEmptyVault();
         }
         IUsdn usdn = s._usdn;
-        uint256 amountAfterFees = amount - FixedPointMathLib.fullMulDiv(amount, s._vaultFeeBps, Constants.BPS_DIVISOR);
-        usdnSharesExpected_ = Utils._calcMintUsdnShares(amountAfterFees, vaultBalance, usdn.totalShares());
+        uint256 fees = FixedPointMathLib.fullMulDiv(amount, s._vaultFeeBps, Constants.BPS_DIVISOR);
+        uint256 amountAfterFees = amount - fees;
+        usdnSharesExpected_ = Utils._calcMintUsdnShares(amountAfterFees, vaultBalance + fees, usdn.totalShares());
         sdexToBurn_ = Utils._calcSdexToBurn(usdn.convertToTokens(usdnSharesExpected_), s._sdexBurnOnDepositRatio);
     }
 


### PR DESCRIPTION
This PR fixes the fees on deposit not being taken into account before calculating the amount of USDN shares the depositor should receive. This would then allow the user to profit from its own action and result in significantly more shares being minted than intended.

Closes RA2BL-119