### PR TITLE
fix(remove-blocked-action): reset the tick penalty if the postiion was the last one in the tick

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
@@ -400,12 +400,14 @@ library UsdnProtocolCoreLibrary {
                     Types.TickData storage tickData = s._tickData[tHash];
                     --s._totalLongPositions;
                     tickData.totalPos -= 1;
+                    uint256 unadjustedTickPrice =
+                        TickMath.getPriceAtTick(Utils.calcTickWithoutPenalty(open.tick, tickData.liquidationPenalty));
                     if (tickData.totalPos == 0) {
                         // we removed the last position in the tick
                         s._tickBitmap.unset(Utils._calcBitmapIndexFromTick(s, open.tick));
+                        // reset tick penalty
+                        tickData.liquidationPenalty = 0;
                     }
-                    uint256 unadjustedTickPrice =
-                        TickMath.getPriceAtTick(Utils.calcTickWithoutPenalty(open.tick, tickData.liquidationPenalty));
                     s._totalExpo -= pos.totalExpo;
                     tickData.totalExpo -= pos.totalExpo;
                     s._liqMultiplierAccumulator =

--- a/test/unit/UsdnProtocol/Core/RemoveBlockedPendingAction.t.sol
+++ b/test/unit/UsdnProtocol/Core/RemoveBlockedPendingAction.t.sol
@@ -234,6 +234,7 @@ contract TestUsdnProtocolRemoveBlockedPendingAction is UsdnProtocolBaseFixture {
         assertEq(tickDataAfter.totalExpo, tickDataBefore.totalExpo, "tick total expo");
         assertEq(tickDataAfter.totalPos, tickDataBefore.totalPos, "tick total pos");
         assertEq(tickDataAfter.totalPos, 0, "no more pos in tick");
+        assertEq(tickDataAfter.liquidationPenalty, 0, "liq penalty reset");
         assertFalse(protocol.tickBitmapStatus(posId.tick), "tick bitmap status");
 
         assertEq(protocol.getTotalLongPositions(), totalPosBefore, "total pos");


### PR DESCRIPTION
If the position is the last one in the tick, the liquidation penalty should be reset.

Closes RA2BL-162