### PR TITLE
feat(multiminter)!: remove the mint function that sends ether

### DIFF
--- a/src/utils/sepolia/MultiMinter.sol
+++ b/src/utils/sepolia/MultiMinter.sol
@@ -27,7 +27,7 @@ interface IMultiMinter {
 
     function acceptOwnershipOf(address contractAdr) external;
 
-    function sweep(address to) external;
+    function sweep(address payable to) external;
 
     function aggregateOnlyOwner(Call[] calldata calls) external payable returns (bytes[] memory returnData);
 }
@@ -80,17 +80,11 @@ contract MultiMinter is IMultiMinter, Ownable2Step {
         IOwnable(contractAdr).acceptOwnership();
     }
 
-    function sweep(address to) external onlyOwner {
+    function sweep(address payable to) external onlyOwner {
+        STETH.sweep(to);
+        WSTETH.sweep(to);
         (bool success,) = to.call{ value: address(this).balance }("");
         require(success, "Error while sending Ether");
-    }
-
-    function sweepStETH(address payable to) external onlyOwner {
-        STETH.sweep(to);
-    }
-
-    function sweepWstETH(address payable to) external onlyOwner {
-        WSTETH.sweep(to);
     }
 
     /**

--- a/test/unit/MultiMinter/MultiMinter.t.sol
+++ b/test/unit/MultiMinter/MultiMinter.t.sol
@@ -66,4 +66,14 @@ contract TestSepoliaMultiMint is Test {
         uint256 ratio = wstETH.stEthPerToken();
         assertEq(ratio, 0.42 ether);
     }
+
+    function test_sweep() public {
+        vm.deal(address(multiMinter), 1 ether);
+        vm.deal(address(stETH), 1 ether);
+        vm.deal(address(wstETH), 1 ether);
+
+        multiMinter.sweep(USER_1);
+
+        assertEq(USER_1.balance, 3 ether);
+    }
 }


### PR DESCRIPTION
Fix and add tests to the multiminter

BREAKING CHANGE: the mint function that took an amount of ether to send as argument has been removed, and the order of the tokens to mint has been changed for consistency's sake. The sweep functions have all been merged into one that will sweep the multmint, stETH and wstETH contracts.