### PR TITLE
fix(blocked-action): send the value of the blocked action to the to address rather than the vault

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
@@ -420,8 +420,9 @@ library UsdnProtocolCoreLibrary {
         } else if (pending.action == Types.ProtocolAction.ValidateClosePosition && cleanup) {
             // for pending closes, the position is already out of the protocol
             Types.LongPendingAction memory close = Utils._toLongPendingAction(pending);
-            // credit the full amount to the vault to preserve the total balance invariant (like a liquidation)
-            s._balanceVault += close.closeBoundedPositionValue;
+            // send the value of the position at the time of the initiate to the `to` address
+            address(s._asset).safeTransfer(to, close.closeBoundedPositionValue);
+            // as the assets were already removed from the long's balance, there are no additional steps needed
         }
 
         // we retrieve the security deposit

--- a/test/unit/UsdnProtocol/Core/RemoveBlockedPendingAction.t.sol
+++ b/test/unit/UsdnProtocol/Core/RemoveBlockedPendingAction.t.sol
@@ -330,18 +330,17 @@ contract TestUsdnProtocolRemoveBlockedPendingAction is UsdnProtocolBaseFixture {
         uint256 balanceBefore = address(this).balance;
         uint256 balanceLongBefore = protocol.getBalanceLong();
         uint256 balanceVaultBefore = protocol.getBalanceVault();
+        uint256 balanceToBefore = wstETH.balanceOf(address(this));
 
         _removeBlockedLongScenario(ProtocolAction.InitiateClosePosition, 10 ether, true, false);
 
         assertApproxEqAbs(protocol.getBalanceLong(), balanceLongBefore, 1, "balance long");
-        assertApproxEqAbs(protocol.getBalanceVault(), balanceVaultBefore + 10 ether, 1, "balance vault");
-        assertEq(
-            protocol.getBalanceLong() + protocol.getBalanceVault(),
-            balanceLongBefore + balanceVaultBefore + 10 ether,
-            "total balance"
-        );
+        assertApproxEqAbs(protocol.getBalanceVault(), balanceVaultBefore, 1, "balance vault");
 
         assertEq(address(this).balance, balanceBefore + protocol.getSecurityDepositValue(), "balance after");
+
+        // -1 because of rounding
+        assertEq(wstETH.balanceOf(address(this)), balanceToBefore + 10 ether - 1, "asset balance after");
     }
 
     /**


### PR DESCRIPTION
Sending the whole position's value to the vault is unnecessary.
Now we simply send the value of the position at the time of the initiate to the `to`  parameter.
I thought about recalculating the value of the position with `lastPrice`, but I though it was a bit overkill, those blocked actions are supposed to be either not happening or a rarity, so we shouldn't overthink it.

Closes RA2BL-177