### PR TITLE
fix(validate-withdrawal): avoid an underflow by sending what remains in the vault

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolFallback.sol
+++ b/src/UsdnProtocol/UsdnProtocolFallback.sol
@@ -87,7 +87,7 @@ contract UsdnProtocolFallback is IUsdnProtocolFallback, UsdnProtocolStorage {
         Storage storage s = Utils._getMainStorage();
 
         uint256 available = Vault.vaultAssetAvailableWithFunding(price, timestamp);
-        assetExpected_ = Utils._calcAssetsFromUsdnBurned(usdnShares, available, s._usdn.totalShares(), s._vaultFeeBps);
+        assetExpected_ = Utils._calcAmountToWithdraw(usdnShares, available, s._usdn.totalShares(), s._vaultFeeBps);
     }
 
     /// @inheritdoc IUsdnProtocolFallback

--- a/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolCoreLibrary.sol
@@ -368,7 +368,7 @@ library UsdnProtocolCoreLibrary {
             Types.WithdrawalPendingAction memory withdrawal = Utils._toWithdrawalPendingAction(pending);
             uint256 shares = Utils._mergeWithdrawalAmountParts(withdrawal.sharesLSB, withdrawal.sharesMSB);
             // calculate the pending amount after fees to update the pending vault balance
-            uint256 pendingAmountAfterFees = Utils._calcAssetsFromUsdnBurned(
+            uint256 pendingAmountAfterFees = Utils._calcAmountToWithdraw(
                 shares, withdrawal.balanceVault, withdrawal.usdnTotalShares, withdrawal.feeBps
             );
             s._pendingBalanceVault += pendingAmountAfterFees.toInt256();

--- a/src/UsdnProtocol/libraries/UsdnProtocolUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolUtilsLibrary.sol
@@ -567,7 +567,7 @@ library UsdnProtocolUtilsLibrary {
      * @param feeBps The fee in basis points
      * @return expectedAssetsAmount_ The expected amount of assets to be received, after fees
      */
-    function _calcAssetsFromUsdnBurned(
+    function _calcAmountToWithdraw(
         uint256 usdnShares,
         uint256 vaultAvailableBalance,
         uint256 usdnSharesTotalSupply,

--- a/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
@@ -835,7 +835,7 @@ library UsdnProtocolVaultLibrary {
         data_.usdnTotalShares = s._usdn.totalShares();
         data_.feeBps = s._vaultFeeBps;
         data_.withdrawalAmountAfterFees =
-            Utils._calcAssetsFromUsdnBurned(usdnShares, data_.balanceVault, data_.usdnTotalShares, data_.feeBps);
+            Utils._calcAmountToWithdraw(usdnShares, data_.balanceVault, data_.usdnTotalShares, data_.feeBps);
         if (data_.withdrawalAmountAfterFees < amountOutMin) {
             revert IUsdnProtocolErrors.UsdnProtocolAmountReceivedTooSmall();
         }
@@ -1027,21 +1027,26 @@ library UsdnProtocolVaultLibrary {
         uint256 shares = Utils._mergeWithdrawalAmountParts(withdrawal.sharesLSB, withdrawal.sharesMSB);
 
         // we can add back the _pendingBalanceVault we subtracted in the initiate action
-        uint256 tempWithdrawalAfterFees = Utils._calcAssetsFromUsdnBurned(
-            shares, withdrawal.balanceVault, withdrawal.usdnTotalShares, withdrawal.feeBps
-        );
+        uint256 tempWithdrawalAfterFees =
+            Utils._calcAmountToWithdraw(shares, withdrawal.balanceVault, withdrawal.usdnTotalShares, withdrawal.feeBps);
         s._pendingBalanceVault += tempWithdrawalAfterFees.toInt256();
 
         IUsdn usdn = s._usdn;
         // calculate the amount of asset to transfer with the same fees as recorded during the initiate action
         uint256 assetToTransferAfterFees =
-            Utils._calcAssetsFromUsdnBurned(shares, available, withdrawal.usdnTotalShares, withdrawal.feeBps);
+            Utils._calcAmountToWithdraw(shares, available, withdrawal.usdnTotalShares, withdrawal.feeBps);
 
         usdn.burnShares(shares);
 
         // send the asset to the user
         if (assetToTransferAfterFees > 0) {
-            s._balanceVault -= assetToTransferAfterFees;
+            uint256 balanceVault = s._balanceVault;
+            // if there aren't enough funds in the vault, send what remains
+            if (assetToTransferAfterFees > balanceVault) {
+                assetToTransferAfterFees = balanceVault;
+            }
+
+            s._balanceVault = balanceVault - assetToTransferAfterFees;
             address(s._asset).safeTransfer(withdrawal.to, assetToTransferAfterFees);
         }
 

--- a/test/unit/UsdnProtocol/Vault/_CalcAmountToWithdraw.t.sol
+++ b/test/unit/UsdnProtocol/Vault/_CalcAmountToWithdraw.t.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.26;
 import { UsdnProtocolBaseFixture } from "../utils/Fixtures.sol";
 
 /**
- * @custom:feature The _calcAssetsFromUsdnBurned internal function of the UsdnProtocolUtilsLibrary contract.
+ * @custom:feature The _calcAmountToWithdraw internal function of the UsdnProtocolUtilsLibrary contract.
  * @custom:background Given a protocol instance that was initialized with default params
  */
-contract TestUsdnProtocolVaultCalcAssetsFromUsdnBurned is UsdnProtocolBaseFixture {
+contract TestUsdnProtocolUtilsLibraryCalcAmountToWithdraw is UsdnProtocolBaseFixture {
     function setUp() public {
         super._setUp(DEFAULT_PARAMS);
     }
@@ -15,28 +15,28 @@ contract TestUsdnProtocolVaultCalcAssetsFromUsdnBurned is UsdnProtocolBaseFixtur
     /**
      * @custom:scenario Check calculation asset received when withdrawing
      * @custom:given A protocol initialized with default params
-     * @custom:when The function "_calcAssetsFromUsdnBurned" is called with some parameters
+     * @custom:when The function "_calcAmountToWithdraw" is called with some parameters
      * @custom:then The asset amount is calculated correctly
      */
-    function test_calcAssetsFromUsdnBurned() public view {
+    function test_calcAmountToWithdraw() public view {
         uint256 usdnShares = 10 ether;
         uint256 available = 10 ether;
         uint256 usdnTotalShares = 10 ether;
-        uint256 assetExpected = protocol.i_calcAssetsFromUsdnBurned(usdnShares, available, usdnTotalShares, 0);
+        uint256 assetExpected = protocol.i_calcAmountToWithdraw(usdnShares, available, usdnTotalShares, 0);
         assertEq(assetExpected, 10 ether, "assetExpected must match with expected value (10 ether)");
-        assetExpected = protocol.i_calcAssetsFromUsdnBurned(usdnShares, available, usdnTotalShares, 1000);
+        assetExpected = protocol.i_calcAmountToWithdraw(usdnShares, available, usdnTotalShares, 1000);
         assertEq(assetExpected, 9 ether, "assetExpected must match with expected value (10% fee)");
 
         usdnShares = 100;
         available = 6 ether;
         usdnTotalShares = 500;
-        assetExpected = protocol.i_calcAssetsFromUsdnBurned(usdnShares, available, usdnTotalShares, 0);
+        assetExpected = protocol.i_calcAmountToWithdraw(usdnShares, available, usdnTotalShares, 0);
         assertEq(assetExpected, 12e17, "assetExpected must match with expected value (12e17)");
 
         usdnShares = 6000 ether;
         available = 1 ether;
         usdnTotalShares = 2 ether;
-        assetExpected = protocol.i_calcAssetsFromUsdnBurned(usdnShares, available, usdnTotalShares, 0);
+        assetExpected = protocol.i_calcAmountToWithdraw(usdnShares, available, usdnTotalShares, 0);
         assertEq(assetExpected, 3e21, "assetExpected must match with expected value (3e21)");
     }
 }

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -572,12 +572,12 @@ contract UsdnProtocolHandler is UsdnProtocolImpl, Test {
         return Utils._calcFixedPrecisionMultiplier(assetPrice, longTradingExpo, accumulator);
     }
 
-    function i_calcAssetsFromUsdnBurned(uint256 usdnShares, uint256 available, uint256 usdnTotalShares, uint256 feeBps)
+    function i_calcAmountToWithdraw(uint256 usdnShares, uint256 available, uint256 usdnTotalShares, uint256 feeBps)
         external
         pure
         returns (uint256 assetExpected_)
     {
-        return Utils._calcAssetsFromUsdnBurned(usdnShares, available, usdnTotalShares, feeBps);
+        return Utils._calcAmountToWithdraw(usdnShares, available, usdnTotalShares, feeBps);
     }
 
     function i_calcTickWithoutPenalty(int24 tick, uint24 liquidationPenalty) external pure returns (int24) {

--- a/test/utils/IUsdnProtocolHandler.sol
+++ b/test/utils/IUsdnProtocolHandler.sol
@@ -354,7 +354,7 @@ interface IUsdnProtocolHandler is IUsdnProtocol {
         external
         view;
 
-    function i_calcAssetsFromUsdnBurned(uint256 usdnShares, uint256 available, uint256 usdnTotalShares, uint256 feeBps)
+    function i_calcAmountToWithdraw(uint256 usdnShares, uint256 available, uint256 usdnTotalShares, uint256 feeBps)
         external
         pure
         returns (uint256 assetExpected_);


### PR DESCRIPTION
In the rare case the vault does not contain enough assets to validate a withdrawal, it will send what remains instead of the calculated value.

Closes RA2BL-185