### PR TITLE
docs: adding warning for a second protocol

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
@@ -668,8 +668,8 @@ library UsdnProtocolVaultLibrary {
 
         if (ERC165Checker.supportsInterface(msg.sender, type(IPaymentCallback).interfaceId)) {
             if (data.sdexToBurn > 0) {
-                // This logic must be modified if this protocol is deployed twice, as an attacker can burn SDEX once for
-                // both deposits
+                // This logic must be modified if this protocol is deployed twice, as an attacker could burn SDEX once
+                // for both deposits by re-entering one protocol from the other.
                 Utils.transferCallback(s._sdex, data.sdexToBurn, Constants.DEAD_ADDRESS);
             }
             Utils.transferCallback(s._asset, params.amount, address(this));


### PR DESCRIPTION
This pr aims to explain why we need to be careful when deploying a second protocol. In this case, an attacker can burn SDEX only once for both protocol

Closes RA2BL-188