### PR TITLE
refactor!: consistent ordering of arguments for `transferPositionOwnership`

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolActions.sol
+++ b/src/UsdnProtocol/UsdnProtocolActions.sol
@@ -162,12 +162,12 @@ abstract contract UsdnProtocolActions is
     }
 
     /// @inheritdoc IUsdnProtocolActions
-    function transferPositionOwnership(PositionId calldata posId, bytes calldata delegationSignature, address newOwner)
+    function transferPositionOwnership(PositionId calldata posId, address newOwner, bytes calldata delegationSignature)
         external
         whenNotPaused
         initializedAndNonReentrant
     {
-        return ActionsUtils.transferPositionOwnership(posId, delegationSignature, _domainSeparatorV4(), newOwner);
+        return ActionsUtils.transferPositionOwnership(posId, newOwner, delegationSignature, _domainSeparatorV4());
     }
 
     /// @inheritdoc IUsdnProtocolActions

--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
@@ -83,9 +83,9 @@ library UsdnProtocolActionsUtilsLibrary {
     /// @notice See {IUsdnProtocolActions}
     function transferPositionOwnership(
         Types.PositionId calldata posId,
+        address newOwner,
         bytes calldata delegationSignature,
-        bytes32 domainSeparatorV4,
-        address newOwner
+        bytes32 domainSeparatorV4
     ) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -104,7 +104,7 @@ library UsdnProtocolActionsUtilsLibrary {
                 revert IUsdnProtocolErrors.UsdnProtocolUnauthorized();
             } else {
                 _verifyTransferPositionOwnershipDelegation(
-                    posId, delegationSignature, domainSeparatorV4, pos.user, newOwner
+                    posId, pos.user, newOwner, delegationSignature, domainSeparatorV4
                 );
             }
         }
@@ -488,18 +488,18 @@ library UsdnProtocolActionsUtilsLibrary {
      * @dev Reverts if the function arguments don't match those included in the signature
      * and if the signer isn't the owner of the position
      * @param posId The unique identifier of the position
+     * @param positionOwner The current position owner
+     * @param newPositionOwner The new position owner
      * @param delegationSignature An EIP712 signature that proves the caller is authorized by the owner of the position
      * to transfer the ownership to a different address on his behalf
      * @param domainSeparatorV4 The domain separator v4
-     * @param positionOwner The current position owner
-     * @param newPositionOwner The new position owner
      */
     function _verifyTransferPositionOwnershipDelegation(
         Types.PositionId calldata posId,
-        bytes calldata delegationSignature,
-        bytes32 domainSeparatorV4,
         address positionOwner,
-        address newPositionOwner
+        address newPositionOwner,
+        bytes calldata delegationSignature,
+        bytes32 domainSeparatorV4
     ) internal {
         Types.Storage storage s = Utils._getMainStorage();
 

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
@@ -285,11 +285,11 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * If the new owner is a contract that supports the `IOwnershipCallback` interface, its `ownershipCallback` function
      * will be called after the transfer of ownership
      * @param posId The unique position ID
+     * @param newOwner The new position owner
      * @param delegationSignature An optional EIP712 signature to provide when position ownership is transferred on the
      * owner's behalf. If used, it needs to be encoded with `abi.encodePacked(r, s, v)`
-     * @param newOwner The new position owner
      */
-    function transferPositionOwnership(PositionId calldata posId, bytes calldata delegationSignature, address newOwner)
+    function transferPositionOwnership(PositionId calldata posId, address newOwner, bytes calldata delegationSignature)
         external;
 
     /**

--- a/test/unit/UsdnProtocol/Actions/TransferPositionOwnership.t.sol
+++ b/test/unit/UsdnProtocol/Actions/TransferPositionOwnership.t.sol
@@ -38,7 +38,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
 
         vm.expectEmit();
         emit PositionOwnershipTransferred(posId, address(this), USER_1);
-        protocol.transferPositionOwnership(posId, "", USER_1);
+        protocol.transferPositionOwnership(posId, USER_1, "");
 
         (Position memory pos,) = protocol.getLongPosition(posId);
         assertEq(pos.user, USER_1, "position user");
@@ -71,7 +71,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
 
         vm.expectEmit();
         emit PositionOwnershipTransferred(posId, address(this), USER_1);
-        protocol.transferPositionOwnership(posId, "", USER_1);
+        protocol.transferPositionOwnership(posId, USER_1, "");
 
         (Position memory pos,) = protocol.getLongPosition(posId);
         assertEq(pos.user, USER_1, "position user");
@@ -114,7 +114,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
 
         vm.expectEmit();
         emit TestOwnershipCallback(address(this), posId);
-        protocol.transferPositionOwnership(posId, "", address(callbackHandler));
+        protocol.transferPositionOwnership(posId, address(callbackHandler), "");
     }
 
     /**
@@ -137,7 +137,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
 
         callbackHandler.setShouldFail(true);
         vm.expectRevert(OwnershipCallbackFailure.selector);
-        protocol.transferPositionOwnership(posId, "", address(callbackHandler));
+        protocol.transferPositionOwnership(posId, address(callbackHandler), "");
     }
 
     /**
@@ -158,7 +158,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
         );
 
         vm.expectRevert(UsdnProtocolUnauthorized.selector);
-        protocol.transferPositionOwnership(posId, "", USER_1);
+        protocol.transferPositionOwnership(posId, USER_1, "");
     }
 
     /**
@@ -180,7 +180,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
 
         vm.expectRevert(UsdnProtocolUnauthorized.selector);
         vm.prank(USER_1);
-        protocol.transferPositionOwnership(posId, "", USER_1);
+        protocol.transferPositionOwnership(posId, USER_1, "");
     }
 
     /**
@@ -201,7 +201,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
         );
 
         vm.expectRevert(UsdnProtocolInvalidAddressTo.selector);
-        protocol.transferPositionOwnership(posId, "", address(0));
+        protocol.transferPositionOwnership(posId, address(0), "");
     }
 
     /**
@@ -227,7 +227,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
         vm.expectRevert(
             abi.encodeWithSelector(UsdnProtocolOutdatedTick.selector, posId.tickVersion + 1, posId.tickVersion)
         );
-        protocol.transferPositionOwnership(posId, "", USER_1);
+        protocol.transferPositionOwnership(posId, USER_1, "");
     }
 
     /**
@@ -264,7 +264,7 @@ contract TestUsdnProtocolTransferPositionOwnership is UsdnProtocolBaseFixture, D
 
         bytes memory delegationSignature =
             _getTransferPositionDelegationSignature(privateKey, protocol.domainSeparatorV4(), delegation);
-        protocol.transferPositionOwnership(posId, delegationSignature, USER_1);
+        protocol.transferPositionOwnership(posId, USER_1, delegationSignature);
 
         (pos,) = protocol.getLongPosition(posId);
         assertEq(pos.user, USER_1, "the new position user should be `USER_1`");

--- a/test/unit/UsdnProtocol/Actions/_VerifyTransferPositionOwnership.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_VerifyTransferPositionOwnership.t.sol
@@ -46,7 +46,7 @@ contract TestUsdnProtocolVerifyTransferPositionOwnershipDelegation is
      */
     function test_verifyTransferPositionOwnershipDelegation() public {
         protocol.i_verifyTransferPositionOwnershipDelegation(
-            _posId, _delegationSignature, _domainSeparatorV4, _positionOwner, USER_1
+            _posId, _positionOwner, USER_1, _delegationSignature, _domainSeparatorV4
         );
 
         assertEq(protocol.getNonce(_positionOwner), _initialNonce + 1, "position owner nonce should be incremented");
@@ -61,7 +61,7 @@ contract TestUsdnProtocolVerifyTransferPositionOwnershipDelegation is
     function test_RevertWhen_verifyTransferPositionOwnershipDelegationChangeParam() public {
         vm.expectRevert(IUsdnProtocolErrors.UsdnProtocolInvalidDelegationSignature.selector);
         protocol.i_verifyTransferPositionOwnershipDelegation(
-            _posId, _delegationSignature, _domainSeparatorV4, _positionOwner, address(this)
+            _posId, _positionOwner, address(this), _delegationSignature, _domainSeparatorV4
         );
     }
 
@@ -76,7 +76,7 @@ contract TestUsdnProtocolVerifyTransferPositionOwnershipDelegation is
 
         vm.expectRevert(IUsdnProtocolErrors.UsdnProtocolInvalidDelegationSignature.selector);
         protocol.i_verifyTransferPositionOwnershipDelegation(
-            _posId, _delegationSignature, _domainSeparatorV4, _positionOwner, USER_1
+            _posId, _positionOwner, USER_1, _delegationSignature, _domainSeparatorV4
         );
     }
 }

--- a/test/unit/UsdnProtocol/Pause.t.sol
+++ b/test/unit/UsdnProtocol/Pause.t.sol
@@ -57,7 +57,7 @@ contract TestUsdnProtocolPausable is UsdnProtocolBaseFixture {
         protocol.refundSecurityDeposit(ADDR_ZERO);
 
         vm.expectRevert(pausedErr);
-        protocol.transferPositionOwnership(emptyPosId, "", ADDR_ZERO);
+        protocol.transferPositionOwnership(emptyPosId, ADDR_ZERO, "");
 
         vm.expectRevert(pausedErr);
         protocol.liquidate("");

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -835,13 +835,13 @@ contract UsdnProtocolHandler is UsdnProtocolImpl, Test {
 
     function i_verifyTransferPositionOwnershipDelegation(
         Types.PositionId calldata posId,
-        bytes calldata delegationSignature,
-        bytes32 domainSeparatorV4,
         address positionOwner,
-        address newPositionOwner
+        address newPositionOwner,
+        bytes calldata delegationSignature,
+        bytes32 domainSeparatorV4
     ) external {
         ActionsUtils._verifyTransferPositionOwnershipDelegation(
-            posId, delegationSignature, domainSeparatorV4, positionOwner, newPositionOwner
+            posId, positionOwner, newPositionOwner, delegationSignature, domainSeparatorV4
         );
     }
 

--- a/test/utils/IUsdnProtocolHandler.sol
+++ b/test/utils/IUsdnProtocolHandler.sol
@@ -461,10 +461,10 @@ interface IUsdnProtocolHandler is IUsdnProtocol {
 
     function i_verifyTransferPositionOwnershipDelegation(
         Types.PositionId calldata posId,
-        bytes calldata delegationSignature,
-        bytes32 domainSeparatorV4,
         address positionOwner,
-        address newPositionOwner
+        address newPositionOwner,
+        bytes calldata delegationSignature,
+        bytes32 domainSeparatorV4
     ) external;
 
     function i_setUsdnRebaseThreshold(uint128 threshold) external;


### PR DESCRIPTION
BREAKING CHANGE: the order of arguments for `IUsdnProtocol.transferPositionOwnership` was changed