### PR TITLE
test: change `snapshot` function for `snapshotState`

### DIFF
--- a/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
+++ b/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
@@ -94,11 +94,11 @@ contract TestForkUsdnProtocolLiquidationGasUsage is
         /* ---------------------------- set up positions ---------------------------- */
 
         _createPosition(200 ether);
-        snapshots.push(vm.snapshot());
+        snapshots.push(vm.snapshotState());
         _createPosition(150 ether);
-        snapshots.push(vm.snapshot());
+        snapshots.push(vm.snapshotState());
         _createPosition(100 ether);
-        snapshots.push(vm.snapshot());
+        snapshots.push(vm.snapshotState());
     }
 
     /**
@@ -137,7 +137,7 @@ contract TestForkUsdnProtocolLiquidationGasUsage is
 
         for (uint16 ticksToLiquidate = 1; ticksToLiquidate <= 3; ++ticksToLiquidate) {
             // revert to a state where there are `ticksToLiquidate` ticks to liquidate
-            vm.revertTo(snapshotsMem[ticksToLiquidate - 1]);
+            vm.revertToState(snapshotsMem[ticksToLiquidate - 1]);
 
             // disable the rebalancer
             vm.prank(SET_EXTERNAL_MANAGER);
@@ -214,7 +214,7 @@ contract TestForkUsdnProtocolLiquidationGasUsage is
         uint256 oracleFee = oracleMiddleware.validationCost(data, ProtocolAction.Liquidation);
 
         // take a snapshot to re-do liquidations with different iterations
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
         for (uint256 i = 0; i < 2; ++i) {
             uint16 ticksToLiquidate = 3;
 
@@ -238,7 +238,7 @@ contract TestForkUsdnProtocolLiquidationGasUsage is
             assertEq(liquidatedTicks.length, ticksToLiquidate, "We expect 3 positions liquidated");
 
             // cancel the liquidation so it's available again
-            vm.revertTo(snapshotId);
+            vm.revertToState(snapshotId);
         }
 
         // calculate the gas used by the rebalancer trigger

--- a/test/integration/UsdnProtocol/ProfitableDeposit.t.sol
+++ b/test/integration/UsdnProtocol/ProfitableDeposit.t.sol
@@ -78,7 +78,7 @@ contract TestUsdnProtocolProfitableDeposit is UsdnProtocolBaseIntegrationFixture
         mockPyth.setPrice(int64(PYTH_PRICE / 1e10));
         vm.stopPrank();
 
-        snapshotId = vm.snapshot();
+        snapshotId = vm.snapshotState();
     }
 
     /**
@@ -91,7 +91,7 @@ contract TestUsdnProtocolProfitableDeposit is UsdnProtocolBaseIntegrationFixture
     function test_ProfitableDeposit() public {
         uint256 usdnBalanceWithArbitrage = _testWithOracleArbitrage();
 
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
         uint256 usdnBalanceWithoutArbitrage = _testWithoutOracleArbitrage();
 
         assertLt(

--- a/test/integration/UsdnProtocol/RebalancerInitiateClosePosition.t.sol
+++ b/test/integration/UsdnProtocol/RebalancerInitiateClosePosition.t.sol
@@ -281,11 +281,11 @@ contract TestRebalancerInitiateClosePosition is
         LiqTickInfo[] memory liqTickInfoArray;
 
         // snapshot and liquidate to get the liquidated ticks data
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
         liqTickInfoArray = protocol.liquidate{
             value: oracleMiddleware.validationCost(MOCK_PYTH_DATA, ProtocolAction.Liquidation)
         }(MOCK_PYTH_DATA);
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         uint256 liquidationRewards = liquidationRewardsManager.getLiquidationRewards(
             liqTickInfoArray, wstEthPrice, false, RebalancerAction.None, ProtocolAction.InitiateClosePosition, "", ""

--- a/test/unit/UsdnProtocol/PositionFees.t.sol
+++ b/test/unit/UsdnProtocol/PositionFees.t.sol
@@ -390,7 +390,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
 
         uint128 depositAmount = 1 ether;
 
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
 
         /* ----------------------- Validate with position fees ---------------------- */
         vm.prank(ADMIN);
@@ -401,7 +401,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         uint256 mintedUsdnWithoutFees = usdnBalanceAfterWithoutFees - usdnBalanceBefore;
 
         /* ----------------------- Validate with position fees ---------------------- */
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         vm.prank(ADMIN);
         protocol.setVaultFeeBps(100); // 1% fees
@@ -436,7 +436,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         setUpUserPositionInVault(address(this), ProtocolAction.ValidateDeposit, depositAmount, price);
 
         // Store the snapshot id to revert to this point after the next test
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
 
         uint256 initialAssetBalance = wstETH.balanceOf(address(this));
 
@@ -459,7 +459,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         uint256 balanceDiffWithFees = finalAssetBalance - initialAssetBalance;
 
         /* --------------------- Validate without position fees --------------------- */
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         protocol.initiateWithdrawal(
             uint128(usdn.sharesOf(address(this))),
@@ -493,7 +493,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         uint128 desiredLiqPrice = 2000 ether / 2;
         bytes memory priceData = abi.encode(2000 ether);
 
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
 
         /* --------------------- Validate without position fees --------------------- */
         vm.prank(ADMIN);
@@ -520,7 +520,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         assertEq(logsWithoutFees[1].topics[0], ValidatedOpenPosition.selector);
 
         /* ----------------------- Validate with position fees ---------------------- */
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         vm.prank(ADMIN);
         protocol.setPositionFeeBps(100); // 1% fees
@@ -562,7 +562,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         uint128 desiredLiqPrice = 2000 ether / 2;
         bytes memory priceData = abi.encode(2000 ether);
 
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
 
         /* ----------------------- Validate with position fees ---------------------- */
         vm.prank(ADMIN);
@@ -607,7 +607,7 @@ contract TestUsdnProtocolPositionFees is UsdnProtocolBaseFixture {
         assertEq(logs[2].topics[0], ValidatedClosePosition.selector);
 
         /* ----------------------- Validate with position fees ---------------------- */
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         vm.prank(ADMIN);
         protocol.setPositionFeeBps(100); // 1% fees

--- a/test/unit/UsdnProtocol/Vault/Vault.t.sol
+++ b/test/unit/UsdnProtocol/Vault/Vault.t.sol
@@ -69,7 +69,7 @@ contract TestUsdnProtocolVault is UsdnProtocolBaseFixture {
         vm.prank(USER_1);
         usdn.approve(address(protocol), type(uint256).max);
 
-        uint256 id = vm.snapshot();
+        uint256 id = vm.snapshotState();
 
         vm.startPrank(USER_1);
         protocol.initiateWithdrawal{ value: securityDeposit }(
@@ -88,7 +88,7 @@ contract TestUsdnProtocolVault is UsdnProtocolBaseFixture {
 
         uint256 user1BalanceOneWithdraw = wstETH.balanceOf(USER_1);
 
-        vm.revertTo(id);
+        vm.revertToState(id);
 
         vm.startPrank(USER_1);
         protocol.initiateWithdrawal{ value: securityDeposit }(


### PR DESCRIPTION
This PR aims to change the deprecated `snapshot` and `revertTo`.

Closes RA2BL-148.