### PR TITLE
perf(protocol): unchecked mul in `positionValue`

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolUtilsLibrary.sol
@@ -222,8 +222,13 @@ library UsdnProtocolUtilsLibrary {
         pure
         returns (uint256 posValue_)
     {
-        // the multiplication cannot overflow because both operands are uint128
-        posValue_ = uint256(posTotalExpo) * (currentPrice - liqPriceWithoutPenalty) / currentPrice;
+        // posValue_ = uint256(posTotalExpo) * (currentPrice - liqPriceWithoutPenalty) / currentPrice;
+        posValue_ = currentPrice - liqPriceWithoutPenalty;
+        unchecked {
+            // the multiplication cannot overflow because both operands are uint128
+            posValue_ *= posTotalExpo;
+        }
+        posValue_ /= currentPrice;
     }
 
     /**


### PR DESCRIPTION
Optimized gas in the `positionValue()` function by using the unchecked multiplication as both operands are `uint256`.

Closes RA2BL-205.