### PR TITLE
fix: make docker-release compatible with router

### DIFF
--- a/script/deployFork.sh
+++ b/script/deployFork.sh
@@ -72,9 +72,7 @@ rolesArr=(
 
 for role in "${rolesArr[@]}"; do
     # Encode role
-    echo "Encode role: $role"
     encodedRole=$(cast keccak "$role")
-    echo "Encoded role: $encodedRole"
     
     # Send transaction
     echo -e "\nGranting role $role to $DEPLOYER_ADDRESS..."
@@ -83,7 +81,6 @@ for role in "${rolesArr[@]}"; do
         "grantRole(bytes32 role, address account)" \
         $encodedRole $DEPLOYER_ADDRESS \
         --private-key $deployerPrivateKey
-    echo "Role $role granted successfully."
 done
 
 popd >/dev/null


### PR DESCRIPTION
The goal of this pr is to make the usdn-contract repo compatible with futur universal-router docker releases. The idea is that:
- universal-router repo can use usdn-contract repo to release a docker image containing both router and usdn-contracts. 
- usdn-contract repo can still release a docker image containing only usdn-contracts.