### PR TITLE
feat!: add `lookAhead` and `maxIter` parameters to `getActionablePendingActions`

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolFallback.sol
+++ b/src/UsdnProtocol/UsdnProtocolFallback.sol
@@ -30,12 +30,12 @@ contract UsdnProtocolFallback is
     AccessControlDefaultAdminRulesUpgradeable
 {
     /// @inheritdoc IUsdnProtocolFallback
-    function getActionablePendingActions(address currentUser, uint256 lookAhead)
+    function getActionablePendingActions(address currentUser, uint256 lookAhead, uint256 maxIter)
         external
         view
         returns (PendingAction[] memory actions_, uint128[] memory rawIndices_)
     {
-        return Vault.getActionablePendingActions(currentUser, lookAhead);
+        return Vault.getActionablePendingActions(currentUser, lookAhead, maxIter);
     }
 
     /// @inheritdoc IUsdnProtocolFallback
@@ -199,8 +199,8 @@ contract UsdnProtocolFallback is
     }
 
     /// @inheritdoc IUsdnProtocolFallback
-    function MAX_ACTIONABLE_PENDING_ACTIONS() external pure returns (uint256) {
-        return Constants.MAX_ACTIONABLE_PENDING_ACTIONS;
+    function MIN_ACTIONABLE_PENDING_ACTIONS_ITER() external pure returns (uint256) {
+        return Constants.MIN_ACTIONABLE_PENDING_ACTIONS_ITER;
     }
 
     /// @inheritdoc IUsdnProtocolFallback

--- a/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
@@ -14,7 +14,7 @@ library UsdnProtocolConstantsLibrary {
     int24 internal constant NO_POSITION_TICK = type(int24).min;
     address internal constant DEAD_ADDRESS = address(0xdead);
     uint256 internal constant MIN_USDN_SUPPLY = 1000;
-    uint256 internal constant MAX_ACTIONABLE_PENDING_ACTIONS = 20;
+    uint256 internal constant MIN_ACTIONABLE_PENDING_ACTIONS_ITER = 20;
     uint256 internal constant MIN_VALIDATION_DEADLINE = 60;
     uint256 internal constant MAX_VALIDATION_DEADLINE = 1 days;
     uint256 internal constant MAX_LIQUIDATION_PENALTY = 1500;

--- a/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
@@ -272,7 +272,7 @@ library UsdnProtocolVaultLibrary {
     }
 
     /// @notice See {IUsdnProtocolVault}
-    function getActionablePendingActions(address currentUser, uint256 lookAhead)
+    function getActionablePendingActions(address currentUser, uint256 lookAhead, uint256 maxIter)
         external
         view
         returns (Types.PendingAction[] memory actions_, uint128[] memory rawIndices_)
@@ -284,9 +284,11 @@ library UsdnProtocolVaultLibrary {
             // empty queue, early return
             return (actions_, rawIndices_);
         }
-        actions_ = new Types.PendingAction[](Constants.MAX_ACTIONABLE_PENDING_ACTIONS);
-        rawIndices_ = new uint128[](Constants.MAX_ACTIONABLE_PENDING_ACTIONS);
-        uint256 maxIter = Constants.MAX_ACTIONABLE_PENDING_ACTIONS;
+        if (maxIter < Constants.MIN_ACTIONABLE_PENDING_ACTIONS_ITER) {
+            maxIter = Constants.MIN_ACTIONABLE_PENDING_ACTIONS_ITER;
+        }
+        actions_ = new Types.PendingAction[](maxIter);
+        rawIndices_ = new uint128[](maxIter);
         if (queueLength < maxIter) {
             maxIter = queueLength;
         }
@@ -494,7 +496,7 @@ library UsdnProtocolVaultLibrary {
             // empty queue, early return
             return (action_, rawIndex_);
         }
-        uint256 maxIter = Constants.MAX_ACTIONABLE_PENDING_ACTIONS;
+        uint256 maxIter = Constants.MIN_ACTIONABLE_PENDING_ACTIONS_ITER;
         if (queueLength < maxIter) {
             maxIter = queueLength;
         }

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolFallback.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolFallback.sol
@@ -27,12 +27,15 @@ interface IUsdnProtocolFallback is IUsdnProtocolTypes {
      * to use a non-zero value in order to account for the interval where the validation transaction will be pending. A
      * value of 30 seconds should already account for most situations and avoid reverts in case an action becomes
      * actionable after a user submits their transaction
+     * @param maxIter The maximum number of iterations when looking through the queue to find actionable pending
+     * actions. Values below MIN_ACTIONABLE_PENDING_ACTIONS_ITER will be clamped to that value, but this parameter can
+     * be used to increase the limit
      * @return actions_ The pending actions if any, otherwise an empty array. Note that some items can be zero-valued
      * and there is no need to provide price data for those (an empty `bytes` suffices)
      * @return rawIndices_ The raw indices of the actionable pending actions in the queue if any, otherwise an empty
      * array
      */
-    function getActionablePendingActions(address currentUser, uint256 lookAhead)
+    function getActionablePendingActions(address currentUser, uint256 lookAhead, uint256 maxIter)
         external
         view
         returns (PendingAction[] memory actions_, uint128[] memory rawIndices_);
@@ -235,10 +238,11 @@ interface IUsdnProtocolFallback is IUsdnProtocolTypes {
     function DEAD_ADDRESS() external view returns (address);
 
     /**
-     * @notice The maximum number of actionable pending action items returned by `getActionablePendingActions`
-     * @return The maximum value
+     * @notice The minimum number of iterations when searching for actionable pending actions in
+     * `getActionablePendingActions`
+     * @return The minimum number of iterations
      */
-    function MAX_ACTIONABLE_PENDING_ACTIONS() external pure returns (uint256);
+    function MIN_ACTIONABLE_PENDING_ACTIONS_ITER() external pure returns (uint256);
 
     /**
      * @notice The lowest margin between the total expo and the balance long

--- a/test/integration/UsdnProtocol/ActionablePendingActions.t.sol
+++ b/test/integration/UsdnProtocol/ActionablePendingActions.t.sol
@@ -60,7 +60,7 @@ contract TestUsdnProtocolActionablePendingActions is UsdnProtocolBaseIntegration
             previousData
         );
         // check that one pending action was validated, only one should remain
-        (Types.PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0);
+        (Types.PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 1, "actions length after");
     }
 
@@ -78,7 +78,7 @@ contract TestUsdnProtocolActionablePendingActions is UsdnProtocolBaseIntegration
         assertEq(validationCost, 1, "validation cost");
         protocol.validateActionablePendingActions{ value: validationCost }(previousData, 10);
         // check that both pending actions were validated
-        (Types.PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0);
+        (Types.PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 0, "actions length after");
     }
 
@@ -96,7 +96,7 @@ contract TestUsdnProtocolActionablePendingActions is UsdnProtocolBaseIntegration
         _pendingActionsHelper();
         // at this moment, only 2 are actionable
         (Types.PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(0), 0);
+            protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(rawIndices.length, 3, "zero lookahead length"); // 3 but second one is empty
         assertTrue(actions[0].action == Types.ProtocolAction.ValidateDeposit, "zero lookahead first action");
         assertTrue(actions[1].action == Types.ProtocolAction.None, "zero lookahead second action");
@@ -104,13 +104,13 @@ contract TestUsdnProtocolActionablePendingActions is UsdnProtocolBaseIntegration
         // in 35 minutes, the second action should be actionable
         // the call below will add this one on top of the existing list thanks to the lookahead, so we should get all 3
         // actions
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 35 minutes);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 35 minutes, 0);
         assertEq(rawIndices.length, 3, "raw indices length");
         assertTrue(actions[0].action == Types.ProtocolAction.ValidateDeposit, "first action");
         assertTrue(actions[1].action == Types.ProtocolAction.ValidateOpenPosition, "second action");
         assertTrue(actions[2].action == Types.ProtocolAction.ValidateDeposit, "third action");
         // check a very high value to make sure everything works
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 1e9);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 1e9, 0);
         assertEq(rawIndices.length, 3, "raw indices length");
     }
 
@@ -161,7 +161,7 @@ contract TestUsdnProtocolActionablePendingActions is UsdnProtocolBaseIntegration
         mockChainlinkOnChain.setRoundData(9, ethPrice, nextRoundTimestamp, nextRoundTimestamp, 9);
 
         (Types.PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(this), 0);
+            protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 3, "actions length before");
         bytes[] memory priceData = new bytes[](3);
         priceData[0] = abi.encode(9); // round ID after the first initiate

--- a/test/integration/UsdnProtocol/ValidateTwoPos.t.sol
+++ b/test/integration/UsdnProtocol/ValidateTwoPos.t.sol
@@ -85,7 +85,7 @@ contract TestForkUsdnProtocolValidateTwoPos is UsdnProtocolBaseIntegrationFixtur
             USER_2, data2, PreviousActionsData(previousData, rawIndices)
         );
         // no more pending action
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "pending actions length");
         vm.stopPrank();
     }

--- a/test/unit/UsdnProtocol/Actions/InitiateDeposit.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InitiateDeposit.t.sol
@@ -119,7 +119,7 @@ contract TestUsdnProtocolActionsInitiateDeposit is UsdnProtocolBaseFixture {
         // no USDN should be minted yet
         assertEq(usdn.totalSupply(), usdnInitialTotalSupply, "usdn total supply");
         // the pending action should not yet be actionable by a third party
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "no pending action");
 
         PendingAction memory action = protocol.getUserPendingAction(validator);
@@ -131,7 +131,7 @@ contract TestUsdnProtocolActionsInitiateDeposit is UsdnProtocolBaseFixture {
 
         // the pending action should be actionable after the validation deadline
         _waitBeforeActionablePendingAction();
-        (actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions[0].to, to, "pending action to");
         assertEq(actions[0].validator, validator, "pending action validator");
     }

--- a/test/unit/UsdnProtocol/Actions/InitiateOpenPosition.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InitiateOpenPosition.t.sol
@@ -154,7 +154,7 @@ contract TestUsdnProtocolActionsInitiateOpenPosition is UsdnProtocolBaseFixture 
         assertEq(protocol.getBalanceLong(), before.balanceLong + uint256(posValue), "balance long");
 
         // the pending action should not yet be actionable by a third party
-        (PendingAction[] memory pendingActions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory pendingActions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(pendingActions.length, 0, "no pending action");
 
         LongPendingAction memory action = protocol.i_toLongPendingAction(protocol.getUserPendingAction(validator));
@@ -168,7 +168,7 @@ contract TestUsdnProtocolActionsInitiateOpenPosition is UsdnProtocolBaseFixture 
 
         // the pending action should be actionable after the validation deadline
         _waitBeforeActionablePendingAction();
-        (pendingActions,) = protocol.getActionablePendingActions(address(0), 0);
+        (pendingActions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         action = protocol.i_toLongPendingAction(pendingActions[0]);
         assertEq(action.to, to, "pending action to");
         assertEq(action.validator, validator, "pending action validator");

--- a/test/unit/UsdnProtocol/Actions/InitiateWithdrawal.t.sol
+++ b/test/unit/UsdnProtocol/Actions/InitiateWithdrawal.t.sol
@@ -144,7 +144,7 @@ contract TestUsdnProtocolActionsInitiateWithdrawal is UsdnProtocolBaseFixture {
         assertEq(usdn.totalSupply(), usdnInitialTotalSupply + initialUsdnBalance, "usdn total supply");
         // the pending action should not yet be actionable by a third party
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(0), 0);
+            protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "no pending action");
 
         WithdrawalPendingAction memory action =
@@ -158,7 +158,7 @@ contract TestUsdnProtocolActionsInitiateWithdrawal is UsdnProtocolBaseFixture {
 
         // the pending action should be actionable after the validation deadline
         _waitBeforeActionablePendingAction();
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions[0].to, to, "pending action user");
         assertEq(actions[0].validator, address(this), "pending action validator");
         assertEq(rawIndices[0], 1, "raw index");

--- a/test/unit/UsdnProtocol/Actions/SecurityDeposit.t.sol
+++ b/test/unit/UsdnProtocol/Actions/SecurityDeposit.t.sol
@@ -203,7 +203,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
             "the user2 should have paid the security deposit"
         );
 
-        (, uint128[] memory rawIndices) = protocol.getActionablePendingActions(address(this), 0);
+        (, uint128[] memory rawIndices) = protocol.getActionablePendingActions(address(this), 0, 0);
         bytes[] memory previousPriceData = new bytes[](rawIndices.length);
         previousPriceData[0] = priceData;
         previousPriceData[1] = priceData;
@@ -1651,7 +1651,7 @@ contract TestUsdnProtocolSecurityDeposit is UsdnProtocolBaseFixture {
         returns (PreviousActionsData memory prevActionsData_)
     {
         (PendingAction[] memory pendingAction, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(user, 0);
+            protocol.getActionablePendingActions(user, 0, 0);
         bytes[] memory prevPriceData = new bytes[](rawIndices.length);
         prevPriceData[0] = priceData;
 

--- a/test/unit/UsdnProtocol/Actions/ValidateActionablePendingActions.t.sol
+++ b/test/unit/UsdnProtocol/Actions/ValidateActionablePendingActions.t.sol
@@ -41,7 +41,7 @@ contract TestUsdnProtocolValidateActionablePendingActions is UsdnProtocolBaseFix
 
         assertEq(validated, 4, "validated actions");
 
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 0, "remaining pending actions");
     }
 
@@ -60,7 +60,7 @@ contract TestUsdnProtocolValidateActionablePendingActions is UsdnProtocolBaseFix
 
         assertEq(validated, 2, "validated actions");
 
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 2, "remaining pending actions");
     }
 
@@ -91,7 +91,7 @@ contract TestUsdnProtocolValidateActionablePendingActions is UsdnProtocolBaseFix
 
         assertEq(validated, 3, "validated actions");
 
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 1, "remaining pending actions");
     }
 
@@ -194,7 +194,7 @@ contract TestUsdnProtocolValidateActionablePendingActions is UsdnProtocolBaseFix
         _waitBeforeActionablePendingAction();
 
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(this), 0);
+            protocol.getActionablePendingActions(address(this), 0, 0);
 
         assertEq(actions.length, 4, "actions length");
 

--- a/test/unit/UsdnProtocol/Actions/_ExecutePendingAction.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ExecutePendingAction.t.sol
@@ -30,7 +30,7 @@ contract TestUsdnProtocolActionsExecutePendingAction is UsdnProtocolBaseFixture 
         assertTrue(executed, "executed");
         assertFalse(liq, "liq");
 
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 0, "remaining pending actions");
 
         PendingAction memory action = protocol.getUserPendingAction(USER_1);
@@ -116,7 +116,7 @@ contract TestUsdnProtocolActionsExecutePendingAction is UsdnProtocolBaseFixture 
         _waitBeforeActionablePendingAction();
 
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(this), 0);
+            protocol.getActionablePendingActions(address(this), 0, 0);
 
         assertEq(actions.length, 1, "actions length");
 

--- a/test/unit/UsdnProtocol/Actions/_ExecutePendingActionOrRevert.t.sol
+++ b/test/unit/UsdnProtocol/Actions/_ExecutePendingActionOrRevert.t.sol
@@ -97,7 +97,7 @@ contract TestUsdnProtocolActionsExecutePendingActionOrRevert is UsdnProtocolBase
 
         protocol.i_executePendingActionOrRevert(data); // should validate `pending` for USER_1
 
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "one pending action left");
         assertEq(actions[0].to, address(this), "pending action to");
         assertEq(actions[0].validator, address(this), "pending action validator");

--- a/test/unit/UsdnProtocol/Pending.t.sol
+++ b/test/unit/UsdnProtocol/Pending.t.sol
@@ -23,29 +23,29 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
     function test_getActionablePendingActions() public {
         // there should be no pending action at this stage
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(0), 0);
+            protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "pending action before initiate");
         // initiate deposit
         setUpUserPositionInVault(address(this), ProtocolAction.InitiateDeposit, 1 ether, 2000 ether);
         PendingAction memory pending = protocol.getUserPendingAction(address(this));
         // the pending action is not yet actionable until the low latency validation deadline
         vm.warp(pending.timestamp + protocol.getLowLatencyValidatorDeadline());
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "pending action after initiate");
         // the pending action is actionable after the low latency validation deadline
         vm.warp(pending.timestamp + protocol.getLowLatencyValidatorDeadline() + 1);
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "actions length");
         assertEq(actions[0].to, address(this), "action to");
         assertEq(actions[0].validator, address(this), "action validator");
         assertEq(rawIndices[0], 0, "raw index");
         // the pending action is not actionable anymore after the low latency delay
         vm.warp(pending.timestamp + oracleMiddleware.getLowLatencyDelay() + 1);
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "pending action after low latency delay");
         // the pending action is again actionable after the on-chain validation deadline
         vm.warp(pending.timestamp + oracleMiddleware.getLowLatencyDelay() + protocol.getOnChainValidatorDeadline() + 1);
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "actions length");
     }
 
@@ -137,7 +137,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         _waitBeforeActionablePendingAction();
 
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(0), 0);
+            protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "actions length");
         assertEq(actions[0].to, USER_3, "to");
         assertEq(actions[0].validator, USER_3, "validator");
@@ -170,7 +170,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
      * @custom:then No actionable pending action is returned
      */
     function test_getActionablePendingActionEmpty() public view {
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "empty list");
     }
 
@@ -212,13 +212,13 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         // the pending action is actionable after the validation deadline
         _waitBeforeActionablePendingAction();
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(0), 0);
+            protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "actions length");
         assertEq(actions[0].to, address(this), "action to");
         assertEq(actions[0].validator, address(this), "action validator");
         assertEq(rawIndices[0], 0, "action rawIndex");
         // but if the user himself calls the function, the action should not be returned
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(this), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(this), 0, 0);
         assertEq(actions.length, 0, "no action");
     }
 
@@ -264,7 +264,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         rawIndices[0] = 0;
         protocol.validateOpenPosition(USER_2, abi.encode(price2), PreviousActionsData(previousData, rawIndices));
         // No more pending action
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "no action");
         (PendingAction memory action,) = protocol.i_getActionablePendingAction();
         assertTrue(action.action == ProtocolAction.None, "no action (internal)");
@@ -293,7 +293,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         sdex.mintAndApprove(USER_3, 100_000 ether, address(protocol), type(uint256).max);
         sdex.mintAndApprove(USER_4, 100_000 ether, address(protocol), type(uint256).max);
         (PendingAction[] memory actions, uint128[] memory rawIndices) =
-            protocol.getActionablePendingActions(address(0), 0);
+            protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 2, "actions length");
         bytes[] memory previousPriceData = new bytes[](actions.length);
         previousPriceData[0] = abi.encode(price1);
@@ -322,7 +322,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         );
 
         // They should have validated both pending actions
-        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0);
+        (actions, rawIndices) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "final actions length");
     }
 
@@ -368,7 +368,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         vm.warp(pendingDeposit.timestamp + oracleMiddleware.getLowLatencyDelay() + 1);
         (PendingAction memory action,) = protocol.i_getActionablePendingAction();
         assertTrue(action.action == ProtocolAction.None, "no action");
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 0, "actions length after 3 actions exceed low latency period");
         // add a fourth pending action
         pendingDeposit.to = USER_4;
@@ -380,21 +380,21 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         // the fourth pending action is now actionable (the others are not yet)
         (action,) = protocol.i_getActionablePendingAction();
         assertEq(action.validator, USER_4, "fourth action");
-        (actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "actions length after fourth action becomes actionable");
         // wait for the first action to become actionable again
         vm.warp(timestamp + oracleMiddleware.getLowLatencyDelay() + protocol.getOnChainValidatorDeadline() + 1);
         // the first action is now actionable
         (action,) = protocol.i_getActionablePendingAction();
         assertEq(action.validator, USER_1, "first action");
-        (actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 1, "actions length after first action becomes actionable again");
         // wait until all actions are actionable
         vm.warp(
             pendingDeposit.timestamp + oracleMiddleware.getLowLatencyDelay() + protocol.getOnChainValidatorDeadline()
                 + 1
         );
-        (actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 4, "actions length when all are actionable");
     }
 
@@ -439,7 +439,7 @@ contract TestUsdnProtocolPending is UsdnProtocolBaseFixture {
         // the first and third actions are now actionable
         (PendingAction memory action,) = protocol.i_getActionablePendingAction();
         assertEq(action.validator, USER_1, "first action");
-        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0);
+        (PendingAction[] memory actions,) = protocol.getActionablePendingActions(address(0), 0, 0);
         assertEq(actions.length, 3, "actions length after two actions are actionable");
         assertEq(actions[0].validator, USER_1, "first action");
         assertEq(actions[1].validator, address(0), "second action (empty)");

--- a/test/unit/UsdnProtocol/Storage/Constructor.t.sol
+++ b/test/unit/UsdnProtocol/Storage/Constructor.t.sol
@@ -91,7 +91,7 @@ contract TestUsdnProtocolStorageConstructor is UsdnProtocolBaseFixture {
      */
     function test_getters() public view {
         assertEq(protocol.LIQUIDATION_MULTIPLIER_DECIMALS(), 38);
-        assertEq(protocol.MAX_ACTIONABLE_PENDING_ACTIONS(), 20);
+        assertEq(protocol.MIN_ACTIONABLE_PENDING_ACTIONS_ITER(), 20);
         assertEq(address(protocol.getSdex()), address(sdex));
         assertEq(protocol.getUsdnMinDivisor(), usdn.MIN_DIVISOR());
         assertEq(protocol.getMiddlewareValidationDelay(), oracleMiddleware.getValidationDelay());


### PR DESCRIPTION
When users interact with the protocol, they must submit price data for pending actions which are actionable, so that the queue gets processed in a timely manner. The implementation of `getActionablePendingActions` allowed to retrieve the list of actionable pending actions at `block.timestamp`. However, if a user submits a transaction while no actionable pending action is returned, but while the tx is pending, a pending action becomes actionable, the user transaction would revert which is bad UX.

To fix this, an additional `lookAhead` parameter has been added, so that pending actions which will become actionable at `block.timestamp + lookAhead` are also returned. This ensures that the transaction can remain pending during `lookAhead` seconds and still execute without reverting, because it will include the necessary price data.

Additionally, the iteration limit has been made configurable, so that consumers can get the necessary data when the queue contains a high sparsity.

BREAKING CHANGE: the `IUsdnProtocol.getActionablePendingActions` function takes two additional parameters `lookAhead` and `maxIter`, the `MAX_ACTIONABLE_PENDING_ACTIONS` constant has been replaced with `MIN_ACTIONABLE_PENDING_ACTIONS_ITER`.

Closes RA2BL-211
Closes RA2BL-219