### PR TITLE
docs: add comment on initiate actions

### DIFF
--- a/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
@@ -24,7 +24,7 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * @param to The address that will be the owner of the position
      * @param validator The address that will validate the open position
      * Be aware that if the validator is not an EOA, it must be a contract that implements a receive function to accept
-     * the returned security deposit
+     * the returned Ether
      * @param deadline The deadline of the open position to be initiated
      * @param currentPriceData  The current price data (used to calculate the temporary leverage and entry price,
      * pending validation)
@@ -102,7 +102,7 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * @param to The address that will receive the assets
      * @param validator The address that will validate the close action
      * Be aware that if the validator is not an EOA, it must be a contract that implements a receive function to accept
-     * the returned security deposit
+     * the returned Ether
      * @param deadline The deadline of the close position to be initiated
      * @param currentPriceData The current price data
      * @param previousActionsData The data needed to validate actionable pending actions
@@ -168,7 +168,7 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * @param to The address that will receive the USDN tokens
      * @param validator The address that will validate the deposit
      * Be aware that if the validator is not an EOA, it must be a contract that implements a receive function to accept
-     * the returned security deposit
+     * the returned Ether
      * @param deadline The deadline of the deposit to be initiated
      * @param currentPriceData The current price data
      * @param previousActionsData The data needed to validate actionable pending actions
@@ -225,7 +225,7 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * @param to The address that will receive the assets
      * @param validator The address that will validate the withdrawal
      * Be aware that if the validator is not an EOA, it must be a contract that implements a receive function to accept
-     * the returned security deposit
+     * the returned Ether
      * @param deadline The deadline of the withdrawal to be initiated
      * @param currentPriceData The current price data
      * @param previousActionsData The data needed to validate actionable pending actions


### PR DESCRIPTION
This PR adds documentation for all `initiate` functions, including a warning that the `validator` must either be an EOA or implement a `receive()` function.

Closes RA2BL-218.