### PR TITLE
feat!: return potentially updated posId in `validateOpenPosition`

### DIFF
--- a/src/UsdnProtocol/UsdnProtocolActions.sol
+++ b/src/UsdnProtocol/UsdnProtocolActions.sol
@@ -51,7 +51,13 @@ abstract contract UsdnProtocolActions is
         address payable validator,
         bytes calldata openPriceData,
         PreviousActionsData calldata previousActionsData
-    ) external payable whenNotPaused initializedAndNonReentrant returns (LongActionOutcome outcome_) {
+    )
+        external
+        payable
+        whenNotPaused
+        initializedAndNonReentrant
+        returns (LongActionOutcome outcome_, PositionId memory posId_)
+    {
         return ActionsLong.validateOpenPosition(validator, openPriceData, previousActionsData);
     }
 

--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol
@@ -271,7 +271,7 @@ library UsdnProtocolActionsUtilsLibrary {
                 } else if (data.pending.action == Types.ProtocolAction.ValidateWithdrawal) {
                     data.executed = Vault._validateWithdrawalWithAction(data.pending, previousActionsData.priceData[i]);
                 } else if (data.pending.action == Types.ProtocolAction.ValidateOpenPosition) {
-                    (data.executed, data.liq) =
+                    (data.executed, data.liq,) =
                         ActionsLong._validateOpenPositionWithAction(data.pending, previousActionsData.priceData[i]);
                 } else if (data.pending.action == Types.ProtocolAction.ValidateClosePosition) {
                     (data.executed, data.liq) =

--- a/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
@@ -446,7 +446,7 @@ library UsdnProtocolVaultLibrary {
         } else if (pending.action == Types.ProtocolAction.ValidateWithdrawal) {
             executed_ = _validateWithdrawalWithAction(pending, priceData);
         } else if (pending.action == Types.ProtocolAction.ValidateOpenPosition) {
-            (executed_, liquidated_) = ActionsLong._validateOpenPositionWithAction(pending, priceData);
+            (executed_, liquidated_,) = ActionsLong._validateOpenPositionWithAction(pending, priceData);
         } else if (pending.action == Types.ProtocolAction.ValidateClosePosition) {
             (executed_, liquidated_) = ActionsLong._validateClosePositionWithAction(pending, priceData);
         }

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolActions.sol
@@ -65,14 +65,15 @@ interface IUsdnProtocolActions is IUsdnProtocolTypes {
      * @param validator The address that has the pending open position action to validate
      * @param openPriceData The price data corresponding to the sender's pending open position action
      * @param previousActionsData The data needed to validate actionable pending actions
-     * @return outcome_ The effect that the call had on the pending action
-     * (processed, liquidated, pending liquidations)
+     * @return outcome_ The effect that the call had on the pending action (processed, liquidated, pending liquidations)
+     * @return posId_ The position ID, which might have changed due to the new entry price moving the position to a new
+     * liquidation tick. If the position was liquidated, then `NO_POSITION_TICK` is returned for the `tick` field
      */
     function validateOpenPosition(
         address payable validator,
         bytes calldata openPriceData,
         PreviousActionsData calldata previousActionsData
-    ) external payable returns (LongActionOutcome outcome_);
+    ) external payable returns (LongActionOutcome outcome_, PositionId memory posId_);
 
     /**
      * @notice Initiate a close position action

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -239,7 +239,7 @@ contract UsdnProtocolHandler is UsdnProtocolImpl, UsdnProtocolFallback, Test {
 
     function i_validateOpenPosition(address user, bytes calldata priceData)
         external
-        returns (uint256 securityDepositValue_, bool isValidated_, bool liquidated_)
+        returns (uint256 securityDepositValue_, bool isValidated_, bool liquidated_, PositionId memory posId_)
     {
         return ActionsLong._validateOpenPosition(user, priceData);
     }


### PR DESCRIPTION
The position ID of a position might change in `validateOpenPosition` due to the max leverage being exceeded and the liquidation tick being changed. We now notify the caller that this might have happened by returning the position ID. In case of liquidation, the return ID is `PositionId(NO_POSITION_TICK, 0, 0)`.

BREAKING CHANGE: `IUsdnProtocol.validateOpenPosition` has a new return value `posId_` with the position ID which could have changed during execution.

Closes RA2BL-208