### PR TITLE
chore: update foundry and lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730711416,
-        "narHash": "sha256-4HyTtqRlFr5wtwNBqk0MahRm2Ik+QduSPIbzR1annPQ=",
+        "lastModified": 1732525825,
+        "narHash": "sha256-5Znq98wSwNW2g122GZwDWcza1sQY+bD2d1USkTijhPU=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "9997167301f964981e751627e6b4302bb3b527e8",
+        "rev": "d9c778babfe32b9e9184a9b1bafc9b5b41566b9b",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730272153,
-        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
+        "lastModified": 1732238832,
+        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730687492,
-        "narHash": "sha256-xQVadjquBA/tFxDt5A55LJ1D1AvkVWsnrKC2o+pr8F4=",
+        "lastModified": 1732328983,
+        "narHash": "sha256-RHt12f/slrzDpSL7SSkydh8wUE4Nr4r23HlpWywed9E=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "41814763a2c597755b0755dbe3e721367a5e420f",
+        "rev": "ed8aa5b64f7d36d9338eb1d0a3bb60cf52069a72",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1726574604,
-        "narHash": "sha256-hLavSA2ocHt1Hms4D3kkk0UPQukD0xGplwB5pzaCamQ=",
+        "lastModified": 1731758759,
+        "narHash": "sha256-NX4+V6Q8bwopah0oza/Dpf6UsYNGbokW2kE9qT3wdHY=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "e035e0c181b176fe3868bd80099bb803d14c0c7f",
+        "rev": "0714c24cd521b9eb3ee435818c5d743ac6179176",
         "type": "github"
       },
       "original": {
@@ -142,13 +142,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-QHhvfpfSeHvDW7zQ/5Dgp9V1T/Mu7BFxPAGGfkiaqxc=",
+        "narHash": "sha256-KBEEpcDeKtVvCeguRP0D499yg9O5Jef9Nxn3yfrmw9g=",
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/a2346e2/macosx-amd64/list.json"
+        "url": "https://github.com/ethereum/solc-bin/raw/67f45d8/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/ethereum/solc-bin/raw/a2346e2/macosx-amd64/list.json"
+        "url": "https://github.com/ethereum/solc-bin/raw/67f45d8/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -3,7 +3,7 @@ name = "@chainlink"
 version = "1.2.0"
 url = "https://github.com/smartcontractkit/chainlink/archive/c3dc764bba9e1c57b3f7933bcb804a1740fab695.zip"
 checksum = "7050515ce90fd3dbac7cb958e960dd22ac85f6d0093bfdec87acc12560edbe3a"
-integrity = "015a826e4ca21760bfad5f746ade4e2eff65d2a92d1706ed5f09caa3911102ce"
+integrity = "327026361885672b88abd3145dc028d1dc549595b6a091cdf37ee67d0c6258f4"
 
 [[dependencies]]
 name = "@openzeppelin-contracts"
@@ -31,14 +31,14 @@ name = "@redstone-finance-evm-connector"
 version = "0.6.2"
 url = "https://soldeer-revisions.s3.amazonaws.com/@redstone-finance-evm-connector/0_6_2_16-09-2024_12:52:33_evm-connector.zip"
 checksum = "2c65c8850894b2e6420827cc1c03ab755d832230679be1bf0835c05aaefbc2bc"
-integrity = "d237d5a10651db7bba806144ff6a0418cac2d56bb33c8348371c5471b5d55f31"
+integrity = "91b013140e1099e6e5d92ef741bcffe7ba5642bc412e616b1dca9801cf3acd6e"
 
 [[dependencies]]
 name = "@uniswap-permit2"
 version = "1.0.0"
 url = "https://github.com/Uniswap/permit2/archive/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219.zip"
 checksum = "180e009e8abfc5ed43383418f2593ac790655b58ec18ae52a92a636d5f298ad4"
-integrity = "d7750a8f2fe466be9d01016b09377e2d42b686d6e3eecb779d70ad75ff24b1f2"
+integrity = "393047bfd13476671149d98263cf25e3ba7d301ef3f9e83f073c0183ea6b6586"
 
 [[dependencies]]
 name = "forge-std"
@@ -52,7 +52,7 @@ name = "openzeppelin-foundry-upgrades"
 version = "0.3.6"
 url = "https://soldeer-revisions.s3.amazonaws.com/openzeppelin-foundry-upgrades/0_3_6_24-09-2024_19:23:05_openzeppelin-foundry-upgrades.zip"
 checksum = "b1d80d9d925e1ac56dfaba7ec59fc6223073c846e71510e963ab1756ccc49ca7"
-integrity = "69389547d11a6726c75068d9d1539eb18ae52421054e366c86c53591be0ba4d7"
+integrity = "4c86e7d43ff517365dfb29362a1abc41f9556b65b97b753b1d2a1e0c6e63f513"
 
 [[dependencies]]
 name = "solady"


### PR DESCRIPTION
The new version of soldeer fixes a small bug with the integrity checksum calculation.