### PR TITLE
docs(validate-open): fix comment about the validation loop now that user liquidates with lastPrice

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsLongLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsLongLibrary.sol
@@ -570,13 +570,9 @@ library UsdnProtocolActionsLongLibrary {
 
         data_.lastPrice = s._lastPrice;
         uint128 liqPriceWithPenalty = Utils._getEffectivePriceForTick(data_.action.tick);
-        // A user that triggers this condition will be stuck in a validation loop. The price it provided is not fresh,
-        // therefore liquidations cannot be triggered, but at the same time, the latest price known by the protocol
-        // indicates that the position should be liquidated. So the owner of this position needs to wait for another
-        // user to update the `lastPrice` to a higher amount, thus dodging the liquidation, or a lower amount, thus
-        // eventually liquidating this position
+        // A user that triggers this condition will be stuck in a validation loop until it liquidates its own position
+        // with the stored `_lastPrice`
         if (data_.lastPrice <= liqPriceWithPenalty) {
-            // the position should be liquidated
             data_.isLiquidationPending = true;
             return (data_, false);
         }


### PR DESCRIPTION
#722 changed the flow for all actions, so users in the situation described by the comment are no longer stuck.