### PR TITLE
docs(usdn): add an @dev to document the lack of accuracy of the totalSupply and balanceOf functions

### DIFF
--- a/src/Usdn/Usdn.sol
+++ b/src/Usdn/Usdn.sol
@@ -104,7 +104,11 @@ contract Usdn is IUsdn, ERC20Permit, ERC20Burnable, AccessControl {
         return _convertToTokens(_totalShares, Rounding.Closest, _divisor);
     }
 
-    /// @inheritdoc IERC20
+    /**
+     * @inheritdoc IERC20
+     * @dev This function does not return an accurate value and is based on the current divisor. Please use {sharesOf}
+     * for an accurate balance of the account
+     */
     function balanceOf(address account) public view override(ERC20, IERC20) returns (uint256) {
         return _convertToTokens(sharesOf(account), Rounding.Closest, _divisor);
     }


### PR DESCRIPTION
This PR aims to document the inaccuracy of the `totalSupply` and `balanceOf` functions.
As the precise amounts are in shares, they just return a conversion of an amount of shares using the current divisor, which introduce precision loss.

Closes RA2BL-246