### PR TITLE
test(limits-setter): enable the limits on set-up to max coverage

### DIFF
--- a/test/unit/UsdnProtocol/Admin.t.sol
+++ b/test/unit/UsdnProtocol/Admin.t.sol
@@ -25,7 +25,7 @@ import { IRebalancerEvents } from "../../../src/interfaces/Rebalancer/IRebalance
  */
 contract TestUsdnProtocolAdmin is UsdnProtocolBaseFixture, IRebalancerEvents {
     function setUp() public {
-        SetUpParams storage params = DEFAULT_PARAMS;
+        params = DEFAULT_PARAMS;
         params.flags.enableLimits = true;
         super._setUp(params);
     }


### PR DESCRIPTION
This PR maximizes the coverage of the setters library by simply enabling the limits flag during test setup.

Closes RA2BL-250.