### PR TITLE
perf: allocate smaller arrays

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolVaultLibrary.sol
@@ -287,11 +287,11 @@ library UsdnProtocolVaultLibrary {
         if (maxIter < Constants.MIN_ACTIONABLE_PENDING_ACTIONS_ITER) {
             maxIter = Constants.MIN_ACTIONABLE_PENDING_ACTIONS_ITER;
         }
-        actions_ = new Types.PendingAction[](maxIter);
-        rawIndices_ = new uint128[](maxIter);
         if (queueLength < maxIter) {
             maxIter = queueLength;
         }
+        actions_ = new Types.PendingAction[](maxIter);
+        rawIndices_ = new uint128[](maxIter);
 
         uint256 lowLatencyDeadline = s._lowLatencyValidatorDeadline;
         // the lookAhead allows to retrieve pending actions which will be actionable some time after block.timestamp. By


### PR DESCRIPTION
We do not need to allocate more space than the number of elements in the queue.

This reduces gas usage for the call significantly.