### PR TITLE
docs(setters-lib): remove markdown trick and replace it with a simpler format

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
@@ -21,10 +21,7 @@ library UsdnProtocolSettersLibrary {
     /*                              SET_EXTERNAL_ROLE                             */
     /* -------------------------------------------------------------------------- */
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setoraclemiddleware).
-     */
+    /// @notice See {UsdnProtocolFallback.setOracleMiddleware}.
     function setOracleMiddleware(IBaseOracleMiddleware newOracleMiddleware) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -39,10 +36,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.OracleMiddlewareUpdated(address(newOracleMiddleware));
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setliquidationrewardsmanager).
-     */
+    /// @notice See {UsdnProtocolFallback.setLiquidationRewardsManager}.
     function setLiquidationRewardsManager(IBaseLiquidationRewardsManager newLiquidationRewardsManager) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -54,10 +48,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.LiquidationRewardsManagerUpdated(address(newLiquidationRewardsManager));
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setrebalancer).
-     */
+    /// @notice See {UsdnProtocolFallback.setRebalancer}.
     function setRebalancer(IBaseRebalancer newRebalancer) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -70,10 +61,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.RebalancerUpdated(address(newRebalancer));
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setfeecollector).
-     */
+    /// @notice See {UsdnProtocolFallback.setFeeCollector}.
     function setFeeCollector(address newFeeCollector) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -89,10 +77,7 @@ library UsdnProtocolSettersLibrary {
     /*                           CRITICAL_FUNCTIONS_ROLE                          */
     /* -------------------------------------------------------------------------- */
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setvalidatordeadlines).
-     */
+    /// @notice See {UsdnProtocolFallback.setValidatorDeadlines}.
     function setValidatorDeadlines(uint128 newLowLatencyValidatorDeadline, uint128 newOnChainValidatorDeadline)
         external
     {
@@ -119,10 +104,7 @@ library UsdnProtocolSettersLibrary {
     /*                          SET_PROTOCOL_PARAMS_ROLE                          */
     /* -------------------------------------------------------------------------- */
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setminleverage).
-     */
+    /// @notice See {UsdnProtocolFallback.setMinLeverage}.
     function setMinLeverage(uint256 newMinLeverage) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -137,10 +119,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.MinLeverageUpdated(newMinLeverage);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setmaxleverage).
-     */
+    /// @notice See {UsdnProtocolFallback.setMaxLeverage}.
     function setMaxLeverage(uint256 newMaxLeverage) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -155,10 +134,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.MaxLeverageUpdated(newMaxLeverage);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setliquidationpenalty).
-     */
+    /// @notice See {UsdnProtocolFallback.setLiquidationPenalty}.
     function setLiquidationPenalty(uint24 newLiquidationPenalty) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -170,10 +146,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.LiquidationPenaltyUpdated(newLiquidationPenalty);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setemaperiod).
-     */
+    /// @notice See {UsdnProtocolFallback.setEMAPeriod}.
     function setEMAPeriod(uint128 newEMAPeriod) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -185,10 +158,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.EMAPeriodUpdated(newEMAPeriod);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setfundingsf).
-     */
+    /// @notice See {UsdnProtocolFallback.setFundingSF}.
     function setFundingSF(uint256 newFundingSF) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -200,10 +170,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.FundingSFUpdated(newFundingSF);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setprotocolfeebps).
-     */
+    /// @notice See {UsdnProtocolFallback.setProtocolFeeBps}.
     function setProtocolFeeBps(uint16 newProtocolFeeBps) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -215,10 +182,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.FeeBpsUpdated(newProtocolFeeBps);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setpositionfeebps).
-     */
+    /// @notice See {UsdnProtocolFallback.setPositionFeeBps}.
     function setPositionFeeBps(uint16 newPositionFee) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -230,10 +194,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.PositionFeeUpdated(newPositionFee);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setvaultfeebps).
-     */
+    /// @notice See {UsdnProtocolFallback.setVaultFeeBps}.
     function setVaultFeeBps(uint16 newVaultFee) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -245,10 +206,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.VaultFeeUpdated(newVaultFee);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setrebalancerbonusbps).
-     */
+    /// @notice See {UsdnProtocolFallback.setRebalancerBonusBps}.
     function setRebalancerBonusBps(uint16 newBonus) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -260,10 +218,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.RebalancerBonusUpdated(newBonus);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setsdexburnondepositratio).
-     */
+    /// @notice See {UsdnProtocolFallback.setSdexBurnOnDepositRatio}.
     function setSdexBurnOnDepositRatio(uint32 newRatio) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -275,10 +230,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.BurnSdexOnDepositRatioUpdated(newRatio);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setsecuritydepositvalue).
-     */
+    /// @notice See {UsdnProtocolFallback.setSecurityDepositValue}.
     function setSecurityDepositValue(uint64 securityDepositValue) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -290,10 +242,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.SecurityDepositValueUpdated(securityDepositValue);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setexpoimbalancelimits).
-     */
+    /// @notice See {UsdnProtocolFallback.setExpoImbalanceLimits}.
     function setExpoImbalanceLimits(
         uint256 newOpenLimitBps,
         uint256 newDepositLimitBps,
@@ -352,10 +301,7 @@ library UsdnProtocolSettersLibrary {
         );
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setminlongposition).
-     */
+    /// @notice See {UsdnProtocolFallback.setMinLongPosition}.
     function setMinLongPosition(uint256 newMinLongPosition) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -376,10 +322,7 @@ library UsdnProtocolSettersLibrary {
     /*                              SET_OPTIONS_ROLE                              */
     /* -------------------------------------------------------------------------- */
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setsafetymarginbps).
-     */
+    /// @notice See {UsdnProtocolFallback.setSafetyMarginBps}.
     function setSafetyMarginBps(uint256 newSafetyMarginBps) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -391,10 +334,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.SafetyMarginBpsUpdated(newSafetyMarginBps);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setliquidationiteration).
-     */
+    /// @notice See {UsdnProtocolFallback.setLiquidationIteration}.
     function setLiquidationIteration(uint16 newLiquidationIteration) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -406,10 +346,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.LiquidationIterationUpdated(newLiquidationIteration);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setfeethreshold).
-     */
+    /// @notice See {UsdnProtocolFallback.setFeeThreshold}.
     function setFeeThreshold(uint256 newFeeThreshold) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -421,10 +358,7 @@ library UsdnProtocolSettersLibrary {
     /*                            SET_USDN_PARAMS_ROLE                            */
     /* -------------------------------------------------------------------------- */
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#settargetusdnprice).
-     */
+    /// @notice See {UsdnProtocolFallback.setTargetUsdnPrice}.
     function setTargetUsdnPrice(uint128 newPrice) external {
         Types.Storage storage s = Utils._getMainStorage();
 
@@ -440,10 +374,7 @@ library UsdnProtocolSettersLibrary {
         emit IUsdnProtocolEvents.TargetUsdnPriceUpdated(newPrice);
     }
 
-    /**
-     * @notice See
-     * [IUsdnProtocolFallback](../../UsdnProtocolFallback.sol/contract.UsdnProtocolFallback.html?#setusdnrebasethreshold).
-     */
+    /// @notice See {UsdnProtocolFallback.setUsdnRebaseThreshold}.
     function setUsdnRebaseThreshold(uint128 newThreshold) external {
         Types.Storage storage s = Utils._getMainStorage();
 


### PR DESCRIPTION
Closes RA2BL-313.

The markdown trick is smart, but is horrid outside of the book generated by `forge doc`.
So the plan would be to use a simpler format, and we will replace those broken links with proper one with an homemade script later.