### PR TITLE
chore: update flake and trufflehog commands

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -25,4 +25,4 @@ jobs:
       - name: TruffleHog
         uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --only-verified --config .trufflehog.yml --exclude-paths=.trufflehog-ignore
+          extra_args: --results=verified,unknown --config .trufflehog.yml --exclude-paths=.trufflehog-ignore

--- a/.trufflehog.example.yml
+++ b/.trufflehog.example.yml
@@ -18,6 +18,8 @@ detectors:
       private_key: '[A-Fa-f0-9]{64}'
     verify:
       - endpoint: '[TRUFFLEHOG_URL]'
+        headers:
+          - 'content-type: application/json'
   - name: evm_mnemonic_detector
     keywords:
       - pk
@@ -36,3 +38,5 @@ detectors:
       mnemonic: '(?:[a-z]{3,8}\s){11}(?:(?:[a-z]{3,8}\s){3}){0,4}[a-z]{3,8}'
     verify:
       - endpoint: '[TRUFFLEHOG_URL]'
+        headers:
+          - 'content-type: application/json'

--- a/flake.lock
+++ b/flake.lock
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732785041,
-        "narHash": "sha256-8XvcjLAFjBzIHYGbJ6qJ1mq5WdJ/j9CYiZbgMHe2Ym8=",
+        "lastModified": 1736154615,
+        "narHash": "sha256-iRCEUvx6AIv5el6//dbZnhL7kPVC21wMOjQeTxT4WhA=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "2387ab07edda81b3de600a8acb5051adb073b499",
+        "rev": "bd38135fe290daf96f1ce65e4b4f93fad1311d84",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732617236,
-        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
+        "lastModified": 1736134818,
+        "narHash": "sha256-30sOEZ8CFK2nTTMdkhaNrfVlIi3rWTNV0Z5z+NmpFNI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
+        "rev": "3df3c47c19dc90fec35359e89ffb52b34d2b0e94",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732802692,
-        "narHash": "sha256-kFrxb45qj52TT/OFUFyTdmvXkn/KXDUL0/DOtjHEQvs=",
+        "lastModified": 1736216977,
+        "narHash": "sha256-EMueGrzBpryM8mgOyoyJ7DdNRRk09ug1ggcLLp0WrCQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "34971069ec33755b2adf2481851f66d8ec9a6bfa",
+        "rev": "bbe7e4e7a70d235db4bbdcabbf8a2f6671881dd7",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -13,8 +13,8 @@ default:
 
 @trufflehog:
     {{ if config_exists == "false" { "just trufflehog-config" } else {""} }}
-    trufflehog git file://. --no-update --config .trufflehog.yml --exclude-paths=.trufflehog-ignore --only-verified --since-commit HEAD --fail
+    trufflehog git file://. --config .trufflehog.yml --exclude-paths=.trufflehog-ignore --results=verified,unknown --since-commit HEAD --fail
 
 @trufflehog-fs:
     {{ if config_exists == "false" { "just trufflehog-config" } else {""} }}
-    trufflehog filesystem --no-update --config .trufflehog.yml --exclude-paths=.trufflehog-ignore-fs --only-verified --fail .
+    trufflehog filesystem --config .trufflehog.yml --exclude-paths=.trufflehog-ignore-fs --results=verified,unknown --fail .


### PR DESCRIPTION
The trufflehog command from nixpkgs now automatically adds the `--no-update` flag so it's not needed anymore. The `--only-verified` flag has been replaced with `--results`. I added headers to the config so that we can later simplify the body parsing in the custom detector lambda.