### PR TITLE
fix(handleNegativeBalances): add check if balances are still negative

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolLongLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolLongLibrary.sol
@@ -1291,12 +1291,9 @@ library UsdnProtocolLongLibrary {
             tempVaultBalance = 0;
         }
 
-        // in case one of the balances is still negative, clamp it to 0
+        // in case the long balance is still negative, clamp it to 0
         if (tempLongBalance < 0) {
             tempLongBalance = 0;
-        }
-        if (tempVaultBalance < 0) {
-            tempVaultBalance = 0;
         }
 
         longBalance_ = tempLongBalance.toUint256();

--- a/test/unit/UsdnProtocol/Long/_HandleNegativeBalances.t.sol
+++ b/test/unit/UsdnProtocol/Long/_HandleNegativeBalances.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { UsdnProtocolBaseFixture } from "../utils/Fixtures.sol";
+
+/**
+ * @custom:feature Test the {_handleNegativeBalances} internal function of the long layer
+ * @custom:background An initialized usdn protocol contract with default parameters
+ */
+contract TestUsdnProtocolHandleNegativeBalances is UsdnProtocolBaseFixture {
+    function setUp() public {
+        super._setUp(DEFAULT_PARAMS);
+    }
+
+    /**
+     * @custom:scenario Verify the clamping of the long balance
+     * @custom:given A vault balance of -200 ether
+     * @custom:and A long balance of 50 ether
+     * @custom:when The {_handleNegativeBalances} function is called
+     * @custom:then The new long balance is 0
+     */
+    function test_longBalanceShouldBe0() public view {
+        int256 vaultBalance = -200 ether;
+        int256 longBalance = 50 ether;
+        (uint256 longBalance_,) = protocol.i_handleNegativeBalances(vaultBalance, longBalance);
+        assertEq(longBalance_, 0, "Long balance should be clamped 0");
+    }
+}

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -870,4 +870,12 @@ contract UsdnProtocolHandler is UsdnProtocolImpl, UsdnProtocolFallback, Test {
     {
         Long._checkOpenPositionLeverage(adjustedPrice, liqPriceWithoutPenalty, userMaxLeverage);
     }
+
+    function i_handleNegativeBalances(int256 tempLongBalance, int256 tempVaultBalance)
+        external
+        pure
+        returns (uint256 longBalance_, uint256 vaultBalance_)
+    {
+        (longBalance_, vaultBalance_) = Long._handleNegativeBalances(tempLongBalance, tempVaultBalance);
+    }
 }


### PR DESCRIPTION
Add a condition in the `handleNegativeBalances()` function to handle the case if the long balance is still negative.

Closes RA2BL-406.