### PR TITLE
fix(middleware): relax round ID check

### DIFF
--- a/src/OracleMiddleware/OracleMiddleware.sol
+++ b/src/OracleMiddleware/OracleMiddleware.sol
@@ -329,12 +329,6 @@ contract OracleMiddleware is IOracleMiddleware, PythOracle, ChainlinkOracle, Acc
                 revert OracleMiddlewareInvalidRoundId();
             }
 
-            (uint80 latestRoundId,,,,) = _priceFeed.latestRoundData();
-            // if the provided round ID does not belong to the latest phase, revert
-            if (latestRoundId >> 64 != roundPhaseId) {
-                revert OracleMiddlewareInvalidRoundId();
-            }
-
             // make sure that the provided round ID is not newer than it should be
             if (providedRoundPrice_.timestamp > targetLimit + _timeElapsedLimit) {
                 revert OracleMiddlewareInvalidRoundId();

--- a/test/unit/Middlewares/Oracle/ParseAndValidatePrice.t.sol
+++ b/test/unit/Middlewares/Oracle/ParseAndValidatePrice.t.sol
@@ -422,32 +422,6 @@ contract TestOracleMiddlewareParseAndValidatePrice is OracleMiddlewareBaseFixtur
     }
 
     /**
-     * @custom:scenario Parse and validate price using Chainlink with the first round ID of a previous phase
-     * @custom:given Enough time has passed that Chainlink is used to validate the pending action
-     * @custom:and The latest round ID is in a newer phase than the provided round ID
-     * @custom:and The validation delay is respected
-     * @custom:and The price timestamp is below the time elapsed limit
-     * @custom:then It reverts with a OracleMiddlewareInvalidRoundId error
-     */
-    function test_RevertWhen_parseAndValidatePriceWithFirstRoundIdOfPreviousPhase() public {
-        bytes memory roundIdData = abi.encode(FIRST_ROUND_ID);
-
-        mockChainlinkOnChain.setRoundData(
-            FIRST_ROUND_ID, int256(ETH_PRICE), LIMIT_TIMESTAMP + 1, LIMIT_TIMESTAMP + 1, FIRST_ROUND_ID
-        );
-        // set the latest round data with a round ID from a newer phase
-        mockChainlinkOnChain.setLatestRoundData((2 << 64) + 1, int256(ETH_PRICE), LIMIT_TIMESTAMP + 2, FIRST_ROUND_ID);
-
-        skip(LOW_LATENCY_DELAY + 1);
-
-        // sanity check
-        assertEq(FIRST_ROUND_ID, (1 << 64) + 1, "The first round ID should be the first valid round of the phase");
-
-        vm.expectRevert(abi.encodeWithSelector(OracleMiddlewareInvalidRoundId.selector));
-        oracleMiddleware.parseAndValidatePrice("", TARGET_TIMESTAMP, Types.ProtocolAction.ValidateDeposit, roundIdData);
-    }
-
-    /**
      * @custom:scenario Parse and validate price using Chainlink with the first round ID of a new, too recent phase
      * @custom:given Enough time has passed that Chainlink is used to validate the pending action
      * @custom:and The latest round ID is the first ID of the phase


### PR DESCRIPTION
The checks that were performed on the `roundId` in case of a phase change between the initiation and validation were too strict and could lead to DoS in case there were multiple `phaseId` changes.

In theory that means that, if there were multiple phase changes after initiation, we would accept any `roundId` that is the first of its phase in the time range `[t+20min, t+82min]`. It's highly unlikely that there would be multiple aggregator changes in such a small amount of time and so it seems acceptable.

Closes RA2BL-408