### PR TITLE
fix(long): avoid edge case underflow in validateOpenPosition above max leverage

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolActionsLongLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolActionsLongLibrary.sol
@@ -297,7 +297,7 @@ library UsdnProtocolActionsLongLibrary {
             // if the last price is below the liquidation price with penalty of the new position, the position is
             // already underwater and we might be unable to calculate the new position value if we are further below
             // `liqPriceWithoutPenalty`
-            // this is extremely unlikely, but we have no other choice but to liquidate it it if happens
+            // this is extremely unlikely, but we have no other choice but to liquidate if it happens
             if (data.lastPrice <= liqPriceWithPenalty) {
                 s._balanceLong -= data.oldPosValue;
                 s._balanceVault += data.oldPosValue;


### PR DESCRIPTION
After re-calculating the liquidation price of the new position with max leverage, it was not checked against the `lastPrice` which could potentially lead to an underflow in the position value calculation. If this would happen, we now liquidate the position individually.

A test for this is hard to create so it will be added later.

Closes RA2BL-424