### PR TITLE
refactor(liq-rewards): update the values for the liquidation rewards

### DIFF
--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -56,10 +56,10 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
     constructor(IWstETH wstETH) Ownable(msg.sender) {
         _wstEth = wstETH;
         _rewardsParameters = RewardsParameters({
-            gasUsedPerTick: 44_666,
-            otherGasUsed: 245_021,
-            rebaseGasUsed: 6955,
-            rebalancerGasUsed: 252_471,
+            gasUsedPerTick: 53_097,
+            otherGasUsed: 469_549,
+            rebaseGasUsed: 13_767,
+            rebalancerGasUsed: 279_349,
             baseFeeOffset: 2 gwei,
             gasMultiplierBps: 10_500, // 1.05
             positionBonusMultiplierBps: 200, // 0.02

--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -56,9 +56,9 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
     constructor(IWstETH wstETH) Ownable(msg.sender) {
         _wstEth = wstETH;
         _rewardsParameters = RewardsParameters({
-            gasUsedPerTick: 53_097,
-            otherGasUsed: 469_549,
-            rebaseGasUsed: 13_767,
+            gasUsedPerTick: 53_094,
+            otherGasUsed: 469_537,
+            rebaseGasUsed: 13_765,
             rebalancerGasUsed: 279_349,
             baseFeeOffset: 2 gwei,
             gasMultiplierBps: 10_500, // 1.05

--- a/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
+++ b/test/integration/UsdnProtocol/LiquidationGasUsage.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.26;
 
-import { Vm } from "forge-std/Vm.sol";
-
 import {
     ADMIN,
     DEPLOYER,


### PR DESCRIPTION
Those values are more accurate than the previous one, compared with activities on Tenderly tests.
We will use the setter to change the values on-chain.

Values updated:

```
gasUsedPerTick: 53_097
otherGasUsed: 469_549
rebaseGasUsed: 13_767
rebalancerGasUsed: 279_349
```

Closes RA2BL-460