### PR TITLE
feat: change version

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity >=0.8.0;
 
 library UsdnProtocolConstantsLibrary {
     /// @notice Number of decimals used for a position's leverage.


### PR DESCRIPTION
USDNProtocolConstantLibrary.sol should not use a fixed Solidity version

Closes RA2BL-481