### PR TITLE
feat: SetRebaseHandlerManager contract

### DIFF
--- a/src/Usdn/SetRebaseHandlerManager.sol
+++ b/src/Usdn/SetRebaseHandlerManager.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+import { IRebaseCallback } from "../interfaces/Usdn/IRebaseCallback.sol";
+import { IUsdn } from "../interfaces/Usdn/IUsdn.sol";
+
+/**
+ * @title SetRebaseHandlerManager.
+ * @notice The contract provides only the ability to set the rebase handler for the USDN token.
+ */
+contract SetRebaseHandlerManager is Ownable2Step {
+    // The USDN token contract.
+    IUsdn public immutable USDN;
+
+    /**
+     * @param usdn The address of the USDN token contract.
+     * @param owner The address of the owner.
+     */
+    constructor(IUsdn usdn, address owner) Ownable(owner) {
+        USDN = usdn;
+    }
+
+    /**
+     * @notice Sets the rebase handler for the USDN token.
+     * @param newHandler The address of the new rebase handler.
+     */
+    function setRebaseHandler(IRebaseCallback newHandler) external onlyOwner {
+        USDN.setRebaseHandler(newHandler);
+    }
+}

--- a/test/unit/USDN/SetRebaseHandlerManager.t.sol
+++ b/test/unit/USDN/SetRebaseHandlerManager.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+import { UsdnTokenFixture } from "./utils/Fixtures.sol";
+
+import { SetRebaseHandlerManager } from "../../../src/Usdn/SetRebaseHandlerManager.sol";
+import { IRebaseCallback } from "../../../src/interfaces/Usdn/IRebaseCallback.sol";
+
+/**
+ * @custom:feature The `setRebaseHandler` function of `SetRebaseHandlerManager`.
+ * @custom:background The `SetRebaseHandlerManager` contract is used to set the rebase handler in the USDN token.
+ */
+contract TestSetRebaseHandlerManager is UsdnTokenFixture {
+    SetRebaseHandlerManager public setRebaseHandlerManager;
+
+    function setUp() public override {
+        super.setUp();
+
+        setRebaseHandlerManager = new SetRebaseHandlerManager(usdn, address(this));
+        usdn.grantRole(0x00, address(setRebaseHandlerManager));
+        usdn.revokeRole(0x00, address(this));
+    }
+
+    /**
+     * @custom:scenario Call `setRebaseHandler` functions and check rebaseHandler change on USDN.
+     * @custom:given The setRebaseHandlerManager has the right role.
+     * @custom:when The `setRebaseHandler` is executed.
+     * @custom:then The rebaseHandler should be changed.
+     */
+    function test_setRebaseHandler() public {
+        IRebaseCallback newHandler = IRebaseCallback(address(0x1));
+        setRebaseHandlerManager.setRebaseHandler(newHandler);
+        assertEq(address(usdn.rebaseHandler()), address(newHandler), "rebaseHandler should be changed");
+    }
+
+    /**
+     * @custom:scenario Call `setRebaseHandler` functions without the manager contract.
+     * @custom:given The caller has no right role.
+     * @custom:when A wallet without right role trigger `setRebaseHandler`.
+     * @custom:then functions should revert with custom "AccessControlUnauthorizedAccount" error.
+     */
+    function test_RevertWhen_setRebaseHandlerWithoutManager() public {
+        IRebaseCallback newHandler = IRebaseCallback(address(0x1));
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), 0x00)
+        );
+        usdn.setRebaseHandler(newHandler);
+    }
+}


### PR DESCRIPTION
This PR aims to have a contract that only provides the ability to setRebaseHandler. This contract will receive the default admin role of Usdn. In this case, nobody can access the mint and the rebase functions.

Closes RA2BL-536