### PR TITLE
feat: add usdn token roles attribution to deployFork

### DIFF
--- a/script/01_DeployProtocol.s.sol
+++ b/script/01_DeployProtocol.s.sol
@@ -314,7 +314,9 @@ contract DeployProtocol is Script {
 
         usdnProtocol.setRebalancer(rebalancer);
 
-        // grant the minter and rebaser roles to the protocol and then renounce the admin role of the deployer
+        // grant the minter and rebaser roles to the protocol
+        usdn.grantRole(usdn.MINTER_ROLE(), address(usdnProtocol));
+        usdn.grantRole(usdn.REBASER_ROLE(), address(usdnProtocol));
         usdn.grantRole(usdn.MINTER_ROLE(), address(_deployerAddress));
         usdn.grantRole(usdn.REBASER_ROLE(), address(_deployerAddress));
 

--- a/script/01_DeployProtocol.s.sol
+++ b/script/01_DeployProtocol.s.sol
@@ -314,7 +314,6 @@ contract DeployProtocol is Script {
 
         usdnProtocol.setRebalancer(rebalancer);
 
-        // grant the minter and rebaser roles to the protocol
         usdn.grantRole(usdn.MINTER_ROLE(), address(usdnProtocol));
         usdn.grantRole(usdn.REBASER_ROLE(), address(usdnProtocol));
         usdn.grantRole(usdn.MINTER_ROLE(), address(_deployerAddress));

--- a/script/01_DeployProtocol.s.sol
+++ b/script/01_DeployProtocol.s.sol
@@ -315,9 +315,8 @@ contract DeployProtocol is Script {
         usdnProtocol.setRebalancer(rebalancer);
 
         // grant the minter and rebaser roles to the protocol and then renounce the admin role of the deployer
-        usdn.grantRole(usdn.MINTER_ROLE(), address(usdnProtocol));
-        usdn.grantRole(usdn.REBASER_ROLE(), address(usdnProtocol));
-        usdn.renounceRole(usdn.DEFAULT_ADMIN_ROLE(), _deployerAddress);
+        usdn.grantRole(usdn.MINTER_ROLE(), address(_deployerAddress));
+        usdn.grantRole(usdn.REBASER_ROLE(), address(_deployerAddress));
 
         uint24 liquidationPenalty = usdnProtocol.getLiquidationPenalty();
         int24 tickSpacing = usdnProtocol.getTickSpacing();

--- a/script/deployFork.sh
+++ b/script/deployFork.sh
@@ -89,7 +89,7 @@ for role in "${usdnTokenRolesArr[@]}"; do
     encodedRole=$(cast keccak "$role")
 
     echo -e "\nGranting role $role to $DEPLOYER_ADDRESS..."
-    cast send $USDN_PROTOCOL_ADDRESS \
+    cast send $USDN_TOKEN_ADDRESS \
         --from $DEPLOYER_ADDRESS \
         "grantRole(bytes32 role, address account)" \
         $encodedRole $DEPLOYER_ADDRESS \

--- a/script/deployFork.sh
+++ b/script/deployFork.sh
@@ -21,7 +21,6 @@ forge script --non-interactive --private-key $deployerPrivateKey -f "$rpcUrl" sc
 chainId=$(cast chain-id -r "$rpcUrl")
 DEPLOYMENT_LOG=$(cat "broadcast/01_DeployProtocol.s.sol/$chainId/run-latest.json")
 
-ADDRESS_0=0x0000000000000000000000000000000000000000
 USDN_TX_HASH=$(echo "$DEPLOYMENT_LOG" | jq '.transactions[] | select(.contractName == "Usdn" and .transactionType == "CREATE") | .hash')
 USDN_RECEIPT=$(echo "$DEPLOYMENT_LOG" | jq ".receipts[] | select(.transactionHash == $USDN_TX_HASH)")
 USDN_PROTOCOL_TX_HASH=$(echo "$DEPLOYMENT_LOG" | jq '.transactions[] | select(.contractName == "ERC1967Proxy" and .transactionType == "CREATE") | .hash')
@@ -78,7 +77,8 @@ for role in "${usdnProtocolRolesArr[@]}"; do
         --from $DEPLOYER_ADDRESS \
         "grantRole(bytes32 role, address account)" \
         $encodedRole $DEPLOYER_ADDRESS \
-        --private-key $deployerPrivateKey
+        --private-key $deployerPrivateKey \
+        --rpc-url $rpcUrl
 done
 
 popd >/dev/null

--- a/script/deployFork.sh
+++ b/script/deployFork.sh
@@ -50,7 +50,7 @@ echo "$FORK_ENV_DUMP"
 echo "$FORK_ENV_DUMP" >.env.fork
 
 # Set all roles for the deployer
-rolesArr=(
+usdnProtocolRolesArr=(
     "ADMIN_SET_EXTERNAL_ROLE"
     "ADMIN_SET_OPTIONS_ROLE"
     "ADMIN_SET_PROTOCOL_PARAMS_ROLE"
@@ -69,7 +69,23 @@ rolesArr=(
     "UNPAUSER_ROLE"
 )
 
-for role in "${rolesArr[@]}"; do
+usdnTokenRolesArr=(
+    "MINTER_ROLE"
+    "REBASER_ROLE"
+)
+
+for role in "${usdnProtocolRolesArr[@]}"; do
+    encodedRole=$(cast keccak "$role")
+
+    echo -e "\nGranting role $role to $DEPLOYER_ADDRESS..."
+    cast send $USDN_PROTOCOL_ADDRESS \
+        --from $DEPLOYER_ADDRESS \
+        "grantRole(bytes32 role, address account)" \
+        $encodedRole $DEPLOYER_ADDRESS \
+        --private-key $deployerPrivateKey
+done
+
+for role in "${usdnTokenRolesArr[@]}"; do
     encodedRole=$(cast keccak "$role")
 
     echo -e "\nGranting role $role to $DEPLOYER_ADDRESS..."

--- a/script/deployFork.sh
+++ b/script/deployFork.sh
@@ -21,6 +21,7 @@ forge script --non-interactive --private-key $deployerPrivateKey -f "$rpcUrl" sc
 chainId=$(cast chain-id -r "$rpcUrl")
 DEPLOYMENT_LOG=$(cat "broadcast/01_DeployProtocol.s.sol/$chainId/run-latest.json")
 
+ADDRESS_0=0x0000000000000000000000000000000000000000
 USDN_TX_HASH=$(echo "$DEPLOYMENT_LOG" | jq '.transactions[] | select(.contractName == "Usdn" and .transactionType == "CREATE") | .hash')
 USDN_RECEIPT=$(echo "$DEPLOYMENT_LOG" | jq ".receipts[] | select(.transactionHash == $USDN_TX_HASH)")
 USDN_PROTOCOL_TX_HASH=$(echo "$DEPLOYMENT_LOG" | jq '.transactions[] | select(.contractName == "ERC1967Proxy" and .transactionType == "CREATE") | .hash')
@@ -69,27 +70,11 @@ usdnProtocolRolesArr=(
     "UNPAUSER_ROLE"
 )
 
-usdnTokenRolesArr=(
-    "MINTER_ROLE"
-    "REBASER_ROLE"
-)
-
 for role in "${usdnProtocolRolesArr[@]}"; do
     encodedRole=$(cast keccak "$role")
 
     echo -e "\nGranting role $role to $DEPLOYER_ADDRESS..."
     cast send $USDN_PROTOCOL_ADDRESS \
-        --from $DEPLOYER_ADDRESS \
-        "grantRole(bytes32 role, address account)" \
-        $encodedRole $DEPLOYER_ADDRESS \
-        --private-key $deployerPrivateKey
-done
-
-for role in "${usdnTokenRolesArr[@]}"; do
-    encodedRole=$(cast keccak "$role")
-
-    echo -e "\nGranting role $role to $DEPLOYER_ADDRESS..."
-    cast send $USDN_TOKEN_ADDRESS \
         --from $DEPLOYER_ADDRESS \
         "grantRole(bytes32 role, address account)" \
         $encodedRole $DEPLOYER_ADDRESS \


### PR DESCRIPTION
**Context:** USDN token is about to be handled into the backend so we need to do e2e testing on it. Therefore we need to set the appropriate USDN token roles into the `deployFork.sh` in order to use it into our anvil docker image.

**Goal of the pr:** Attribute USDN token roles into `deployFork.sh`. 