### PR TITLE
feat: add a version of the USDN token with no rebase

### DIFF
--- a/src/Usdn/UsdnNoRebase.sol
+++ b/src/Usdn/UsdnNoRebase.sol
@@ -107,7 +107,7 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
 
     /// @inheritdoc IUsdn
     function divisor() external pure returns (uint256 divisor_) {
-        divisor_ = MAX_DIVISOR;
+        divisor_ = MIN_DIVISOR;
     }
 
     /// @inheritdoc IUsdn
@@ -156,7 +156,7 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
     /// @inheritdoc IUsdn
     function rebase(uint256) external pure returns (bool rebased_, uint256 oldDivisor_, bytes memory callbackResult_) {
         rebased_ = false;
-        oldDivisor_ = MAX_DIVISOR;
+        oldDivisor_ = MIN_DIVISOR;
         callbackResult_ = bytes("");
     }
 

--- a/src/Usdn/UsdnNoRebase.sol
+++ b/src/Usdn/UsdnNoRebase.sol
@@ -82,7 +82,7 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
 
     /// @inheritdoc IUsdn
     function sharesOf(address account) public view returns (uint256 shares_) {
-        return balanceOf(account);
+        shares_ = balanceOf(account);
     }
 
     /// @inheritdoc IUsdn
@@ -107,7 +107,7 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
 
     /// @inheritdoc IUsdn
     function divisor() external pure returns (uint256 divisor_) {
-        return MAX_DIVISOR;
+        divisor_ = MAX_DIVISOR;
     }
 
     /// @inheritdoc IUsdn
@@ -115,7 +115,7 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
 
     /// @inheritdoc IUsdn
     function maxTokens() public pure returns (uint256 maxTokens_) {
-        return type(uint256).max;
+        maxTokens_ = type(uint256).max;
     }
 
     /// @inheritdoc IUsdn

--- a/src/Usdn/UsdnNoRebase.sol
+++ b/src/Usdn/UsdnNoRebase.sol
@@ -27,13 +27,13 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
      * @inheritdoc IUsdn
      * @dev Only here to match the `IUsdn` interface, this contract uses `Ownable` instead.
      */
-    bytes32 public constant MINTER_ROLE = bytes32(0);
+    bytes32 public constant MINTER_ROLE = "";
 
     /**
      * @inheritdoc IUsdn
      * @dev Only here to match the `IUsdn` interface, this contract uses `Ownable` instead.
      */
-    bytes32 public constant REBASER_ROLE = bytes32(0);
+    bytes32 public constant REBASER_ROLE = "";
 
     /**
      * @inheritdoc IUsdn
@@ -120,12 +120,12 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
 
     /// @inheritdoc IUsdn
     function transferShares(address to, uint256 value) external returns (bool success_) {
-        return transfer(to, value);
+        success_ = transfer(to, value);
     }
 
     /// @inheritdoc IUsdn
     function transferSharesFrom(address from, address to, uint256 value) external returns (bool success_) {
-        return transferFrom(from, to, value);
+        success_ = transferFrom(from, to, value);
     }
 
     /// @inheritdoc IUsdn
@@ -157,7 +157,7 @@ contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
     function rebase(uint256) external pure returns (bool rebased_, uint256 oldDivisor_, bytes memory callbackResult_) {
         rebased_ = false;
         oldDivisor_ = MIN_DIVISOR;
-        callbackResult_ = bytes("");
+        callbackResult_ = "";
     }
 
     /// @inheritdoc IUsdn

--- a/src/Usdn/UsdnNoRebase.sol
+++ b/src/Usdn/UsdnNoRebase.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20Burnable } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+
+import { IRebaseCallback } from "../interfaces/Usdn/IRebaseCallback.sol";
+import { IUsdn } from "../interfaces/Usdn/IUsdn.sol";
+
+/**
+ * @title USDN Token Contract Without Rebases
+ * @notice The USDN token supports the USDN Protocol. It is minted when assets are deposited into the USDN Protocol
+ * vault and burned when withdrawn. While the original USDN token implement rebases to inflates its supply to stay as
+ * close to a certain price as possible, this version removes all of this logic to be used with a protocol that does not
+ * have any target price.
+ * @dev As rebasing is completely disabled, 1 share always equals to 1 token, and the divisor never changes.
+ */
+contract UsdnNoRebase is IUsdn, ERC20Permit, ERC20Burnable, Ownable {
+    /* -------------------------------------------------------------------------- */
+    /*                                  Constants                                 */
+    /* -------------------------------------------------------------------------- */
+
+    /**
+     * @inheritdoc IUsdn
+     * @dev Only here to match the `IUsdn` interface, this contract uses `Ownable` instead.
+     */
+    bytes32 public constant MINTER_ROLE = bytes32(0);
+
+    /**
+     * @inheritdoc IUsdn
+     * @dev Only here to match the `IUsdn` interface, this contract uses `Ownable` instead.
+     */
+    bytes32 public constant REBASER_ROLE = bytes32(0);
+
+    /**
+     * @inheritdoc IUsdn
+     * @dev Only here to match the `IUsdn` interface, this contract does not use shares.
+     */
+    uint256 public constant MAX_DIVISOR = 1;
+
+    /**
+     * @inheritdoc IUsdn
+     * @dev Only here to match the `IUsdn` interface, this contract does not use shares.
+     */
+    uint256 public constant MIN_DIVISOR = 1;
+
+    /**
+     * @param name The name of the ERC20 token.
+     * @param symbol The symbol of the ERC20 token.
+     */
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) ERC20Permit(name) Ownable(msg.sender) { }
+
+    /* -------------------------------------------------------------------------- */
+    /*                            ERC-20 view functions                           */
+    /* -------------------------------------------------------------------------- */
+
+    /// @inheritdoc IERC20Permit
+    function nonces(address owner) public view override(IERC20Permit, ERC20Permit) returns (uint256) {
+        return super.nonces(owner);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                            ERC-20 base functions                           */
+    /* -------------------------------------------------------------------------- */
+
+    /// @inheritdoc IUsdn
+    function burn(uint256 value) public override(ERC20Burnable, IUsdn) {
+        super.burn(value);
+    }
+
+    /// @inheritdoc IUsdn
+    function burnFrom(address account, uint256 value) public override(ERC20Burnable, IUsdn) {
+        super.burnFrom(account, value);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                           Special token functions                          */
+    /* -------------------------------------------------------------------------- */
+
+    /// @inheritdoc IUsdn
+    function sharesOf(address account) public view returns (uint256 shares_) {
+        return balanceOf(account);
+    }
+
+    /// @inheritdoc IUsdn
+    function totalShares() external view returns (uint256 shares_) {
+        shares_ = totalSupply();
+    }
+
+    /// @inheritdoc IUsdn
+    function convertToTokens(uint256 amountShares) external pure returns (uint256 tokens_) {
+        tokens_ = amountShares;
+    }
+
+    /// @inheritdoc IUsdn
+    function convertToTokensRoundUp(uint256 amountShares) external pure returns (uint256 tokens_) {
+        tokens_ = amountShares;
+    }
+
+    /// @inheritdoc IUsdn
+    function convertToShares(uint256 amountTokens) public pure returns (uint256 shares_) {
+        shares_ = amountTokens;
+    }
+
+    /// @inheritdoc IUsdn
+    function divisor() external pure returns (uint256 divisor_) {
+        return MAX_DIVISOR;
+    }
+
+    /// @inheritdoc IUsdn
+    function rebaseHandler() external pure returns (IRebaseCallback) { }
+
+    /// @inheritdoc IUsdn
+    function maxTokens() public pure returns (uint256 maxTokens_) {
+        return type(uint256).max;
+    }
+
+    /// @inheritdoc IUsdn
+    function transferShares(address to, uint256 value) external returns (bool success_) {
+        return transfer(to, value);
+    }
+
+    /// @inheritdoc IUsdn
+    function transferSharesFrom(address from, address to, uint256 value) external returns (bool success_) {
+        return transferFrom(from, to, value);
+    }
+
+    /// @inheritdoc IUsdn
+    function burnShares(uint256 value) external {
+        super.burn(value);
+    }
+
+    /// @inheritdoc IUsdn
+    function burnSharesFrom(address account, uint256 value) public {
+        super.burnFrom(account, value);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                            Privileged functions                            */
+    /* -------------------------------------------------------------------------- */
+
+    /// @inheritdoc IUsdn
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    /// @inheritdoc IUsdn
+    function mintShares(address to, uint256 amount) external onlyOwner returns (uint256 mintedTokens_) {
+        _mint(to, amount);
+        mintedTokens_ = amount;
+    }
+
+    /// @inheritdoc IUsdn
+    function rebase(uint256) external pure returns (bool rebased_, uint256 oldDivisor_, bytes memory callbackResult_) {
+        rebased_ = false;
+        oldDivisor_ = MAX_DIVISOR;
+        callbackResult_ = bytes("");
+    }
+
+    /// @inheritdoc IUsdn
+    function setRebaseHandler(IRebaseCallback) external pure {
+        revert UsdnRebaseNotSupported();
+    }
+}

--- a/src/interfaces/Usdn/IUsdnErrors.sol
+++ b/src/interfaces/Usdn/IUsdnErrors.sol
@@ -22,4 +22,7 @@ interface IUsdnErrors {
 
     /// @dev The divisor value in storage is invalid (< 1).
     error UsdnInvalidDivisor();
+
+    /// @dev The current implementation does not allow rebasing.
+    error UsdnRebaseNotSupported();
 }

--- a/test/unit/USDN/Burn.t.sol
+++ b/test/unit/USDN/Burn.t.sol
@@ -5,7 +5,7 @@ import { USER_1 } from "../../../test/utils/Constants.sol";
 import { UsdnTokenFixture } from "./utils/Fixtures.sol";
 
 /**
- * @custom:feature The `burnShares` function of `USDN`
+ * @custom:feature The `burn` function of `USDN`
  * @custom:background Given a user with 100 tokens
  */
 contract TestUsdnBurnTokens is UsdnTokenFixture {

--- a/test/unit/UsdnNoRebase/Burn.sol
+++ b/test/unit/UsdnNoRebase/Burn.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `burn` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ */
+contract TestUsdnNoRebaseBurn is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        usdn.mint(address(this), 100 ether);
+    }
+
+    /**
+     * @custom:scenario User burning its tokens
+     * @custom:when 50 USDN are burned
+     * @custom:then The `Transfer` event is emitted with this address as the sender, this contract as the recipient and
+     * amount 50
+     * @custom:and This address' balance is decreased by 50
+     */
+    function test_burn() public {
+        vm.expectEmit(address(usdn));
+        emit Transfer(address(this), address(0), 50 ether);
+        usdn.burn(50 ether);
+
+        assertEq(usdn.balanceOf(address(this)), 50 ether, "balance after burn");
+    }
+
+    /**
+     * @custom:scenario Burning with insufficient balance
+     * @custom:when 150 USDN are burned from this address
+     * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
+     */
+    function test_RevertWhen_burnInsufficientBalance() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, address(this), 100 ether, 150 ether)
+        );
+        usdn.burn(150 ether);
+    }
+}

--- a/test/unit/UsdnNoRebase/BurnFrom.t.sol
+++ b/test/unit/UsdnNoRebase/BurnFrom.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `burnFrom` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ */
+contract TestUsdnNoRebaseBurnFrom is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        usdn.mint(USER_1, 100 ether);
+    }
+
+    /**
+     * @custom:scenario Burning from a user with allowance
+     * @custom:given An approved amount of 50 USDN
+     * @custom:when 50 USDN are burned from the user
+     * @custom:then The `Transfer` event is emitted with the user as the sender, this contract as the recipient and
+     * amount 50
+     * @custom:and The user's balance is decreased by 50
+     * @custom:and The allowance is decreased by 50
+     */
+    function test_burnFrom() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), 50 ether);
+
+        vm.expectEmit(address(usdn));
+        emit Transfer(USER_1, address(0), 50 ether);
+        usdn.burnFrom(USER_1, 50 ether);
+
+        assertEq(usdn.balanceOf(USER_1), 50 ether, "balance after burn");
+        assertEq(usdn.allowance(USER_1, address(this)), 0, "allowance after burn");
+    }
+
+    /**
+     * @custom:scenario Burning from a user with insufficient allowance
+     * @custom:given An approved amount of 50 USDN
+     * @custom:when 51 USDN are burned from the user
+     * @custom:then The transaction reverts with the `ERC20InsufficientAllowance` error
+     */
+    function test_RevertWhen_burnFromInsufficientAllowance() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), 50 ether);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(this), 50 ether, 51 ether)
+        );
+        usdn.burnFrom(USER_1, 51 ether);
+    }
+
+    /**
+     * @custom:scenario Burning from a user with insufficient balance
+     * @custom:given An approved amount of max
+     * @custom:when 150 USDN are burned from the user
+     * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
+     */
+    function test_RevertWhen_burnFromInsufficientBalance() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), type(uint256).max);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, USER_1, 100 ether, 150 ether)
+        );
+        usdn.burnFrom(USER_1, 150 ether);
+    }
+}

--- a/test/unit/UsdnNoRebase/BurnShares.sol
+++ b/test/unit/UsdnNoRebase/BurnShares.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `burnShares` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ */
+contract TestUsdnNoRebaseBurnShares is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        usdn.mintShares(address(this), 100 ether);
+    }
+
+    /**
+     * @custom:scenario Users burning its tokens
+     * @custom:when 50 USDN are burned
+     * @custom:then The `Transfer` event is emitted with this address as the sender, this contract as the recipient and
+     * amount 50
+     * @custom:and This address' balance is decreased by 50
+     */
+    function test_burnShares() public {
+        vm.expectEmit(address(usdn));
+        emit Transfer(address(this), address(0), 50 ether);
+        usdn.burnShares(50 ether);
+
+        assertEq(usdn.balanceOf(address(this)), 50 ether, "balance after burn");
+    }
+
+    /**
+     * @custom:scenario Burning with insufficient balance
+     * @custom:when 150 USDN are burned from this address
+     * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
+     */
+    function test_RevertWhen_burnSharesInsufficientBalance() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, address(this), 100 ether, 150 ether)
+        );
+        usdn.burnShares(150 ether);
+    }
+}

--- a/test/unit/UsdnNoRebase/BurnShares.sol
+++ b/test/unit/UsdnNoRebase/BurnShares.sol
@@ -18,9 +18,9 @@ contract TestUsdnNoRebaseBurnShares is UsdnNoRebaseTokenFixture {
     /**
      * @custom:scenario Users burning its tokens
      * @custom:when 50 USDN are burned
-     * @custom:then The `Transfer` event is emitted with this address as the sender, this contract as the recipient and
-     * amount 50
-     * @custom:and This address' balance is decreased by 50
+     * @custom:then The `Transfer` event is emitted with this address as the sender, the 0 address as the recipient and
+     * an amount of 50 ether
+     * @custom:and This address' balance is decreased by 50 ether
      */
     function test_burnShares() public {
         vm.expectEmit(address(usdn));

--- a/test/unit/UsdnNoRebase/BurnSharesFrom.t.sol
+++ b/test/unit/UsdnNoRebase/BurnSharesFrom.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `burnSharesFrom` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ */
+contract TestUsdnNoRebaseBurnSharesFrom is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        usdn.mint(USER_1, 100 ether);
+    }
+
+    /**
+     * @custom:scenario Burning from a user with allowance
+     * @custom:given An approved amount of 50 USDN
+     * @custom:when 50 USDN are burned from the user
+     * @custom:then The `Transfer` event is emitted with the user as the sender, this contract as the recipient and
+     * amount 50
+     * @custom:and The user's balance is decreased by 50
+     * @custom:and The allowance is decreased by 50
+     */
+    function test_burnSharesFrom() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), 50 ether);
+
+        vm.expectEmit(address(usdn));
+        emit Transfer(USER_1, address(0), 50 ether);
+        usdn.burnSharesFrom(USER_1, 50 ether);
+
+        assertEq(usdn.balanceOf(USER_1), 50 ether, "balance after burn");
+        assertEq(usdn.allowance(USER_1, address(this)), 0, "allowance after burn");
+    }
+
+    /**
+     * @custom:scenario Burning from a user with insufficient allowance
+     * @custom:given An approved amount of 50 USDN
+     * @custom:when 51 USDN are burned from the user
+     * @custom:then The transaction reverts with the `ERC20InsufficientAllowance` error
+     */
+    function test_RevertWhen_burnSharesFromInsufficientAllowance() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), 50 ether);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(this), 50 ether, 51 ether)
+        );
+        usdn.burnSharesFrom(USER_1, 51 ether);
+    }
+
+    /**
+     * @custom:scenario Burning from a user with insufficient balance
+     * @custom:given An approved amount of max
+     * @custom:when 150 USDN are burned from the user
+     * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
+     */
+    function test_RevertWhen_burnSharesFromInsufficientBalance() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), type(uint256).max);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, USER_1, 100 ether, 150 ether)
+        );
+        usdn.burnSharesFrom(USER_1, 150 ether);
+    }
+}

--- a/test/unit/UsdnNoRebase/BurnSharesFrom.t.sol
+++ b/test/unit/UsdnNoRebase/BurnSharesFrom.t.sol
@@ -20,10 +20,10 @@ contract TestUsdnNoRebaseBurnSharesFrom is UsdnNoRebaseTokenFixture {
      * @custom:scenario Burning from a user with allowance
      * @custom:given An approved amount of 50 USDN
      * @custom:when 50 USDN are burned from the user
-     * @custom:then The `Transfer` event is emitted with the user as the sender, this contract as the recipient and
-     * amount 50
-     * @custom:and The user's balance is decreased by 50
-     * @custom:and The allowance is decreased by 50
+     * @custom:then The `Transfer` event is emitted with the user as the sender, the 0 address as the recipient and
+     * an amount of 50 ether
+     * @custom:and The user's balance is decreased by 50 ether
+     * @custom:and The allowance is decreased by 50 ether
      */
     function test_burnSharesFrom() public {
         vm.prank(USER_1);

--- a/test/unit/UsdnNoRebase/Mint.t.sol
+++ b/test/unit/UsdnNoRebase/Mint.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `mint` function of `UsdnNoRebase`
+ * @custom:background Given this contract is the contract owner
+ */
+contract TestUsdnNoRebaseMint is UsdnNoRebaseTokenFixture {
+    /**
+     * @custom:scenario Minting tokens to the zero address
+     * @custom:when 100 tokens are minted to the zero address
+     * @custom:then The transaction reverts with the `ERC20InvalidReceiver` error
+     */
+    function test_RevertWhen_mintToZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InvalidReceiver.selector, address(0)));
+        usdn.mint(address(0), 100);
+    }
+
+    /**
+     * @custom:scenario Minting tokens without being the owner
+     * @custom:when Tokens are minted from an address that is not the owner
+     * @custom:then The transaction reverts with the `OwnableUnauthorizedAccount` error
+     */
+    function test_RevertWhen_mintSharesFromNonOwnerAddress() public {
+        vm.prank(USER_1);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, USER_1));
+        usdn.mint(address(this), 100);
+    }
+
+    /**
+     * @custom:scenario A user mints tokens
+     * @custom:when 100 tokens are minted for a user
+     * @custom:then The `Transfer` event should be emitted with the zero address as the sender, the user as the
+     * recipient, and the minted amount
+     * @custom:and The user's token balance should match the minted amount
+     */
+    function test_mint() public {
+        vm.expectEmit(address(usdn));
+        emit Transfer(address(0), address(this), 100 ether);
+        usdn.mint(address(this), 100 ether);
+
+        assertEq(usdn.balanceOf(address(this)), 100 ether, "balance of user");
+        assertEq(usdn.sharesOf(address(this)), 100 ether, "shares of user");
+    }
+}

--- a/test/unit/UsdnNoRebase/MintShares.t.sol
+++ b/test/unit/UsdnNoRebase/MintShares.t.sol
@@ -8,10 +8,10 @@ import { USER_1 } from "../../utils/Constants.sol";
 import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
 
 /**
- * @custom:feature The `mintShares` function of `USDN`
+ * @custom:feature The `mintShares` function of `UsdnNoRebase`
  * @custom:background Given this contract is the contract owner
  */
-contract TestUsdnMintShares is UsdnNoRebaseTokenFixture {
+contract TestUsdnNoRebaseMintShares is UsdnNoRebaseTokenFixture {
     /**
      * @custom:scenario Minting shares to the zero address
      * @custom:when 100 shares are minted to the zero address
@@ -42,7 +42,7 @@ contract TestUsdnMintShares is UsdnNoRebaseTokenFixture {
      */
     function test_mintShares() public {
         vm.expectEmit(address(usdn));
-        emit Transfer(address(0), USER_1, 100 ether);
+        emit Transfer(address(0), address(this), 100 ether);
         usdn.mint(address(this), 100 ether);
 
         assertEq(usdn.balanceOf(address(this)), 100 ether, "balance of user");

--- a/test/unit/UsdnNoRebase/MintShares.t.sol
+++ b/test/unit/UsdnNoRebase/MintShares.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `mintShares` function of `USDN`
+ * @custom:background Given this contract is the contract owner
+ */
+contract TestUsdnMintShares is UsdnNoRebaseTokenFixture {
+    /**
+     * @custom:scenario Minting shares to the zero address
+     * @custom:when 100 shares are minted to the zero address
+     * @custom:then The transaction reverts with the `ERC20InvalidReceiver` error
+     */
+    function test_RevertWhen_mintSharesToZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InvalidReceiver.selector, address(0)));
+        usdn.mintShares(address(0), 100);
+    }
+
+    /**
+     * @custom:scenario Minting shares without being the owner
+     * @custom:when Shares are minted from an address that is not the owner
+     * @custom:then The transaction reverts with the `OwnableUnauthorizedAccount` error
+     */
+    function test_RevertWhen_mintSharesFromNonOwnerAddress() public {
+        vm.prank(USER_1);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, USER_1));
+        usdn.mintShares(address(this), 100);
+    }
+
+    /**
+     * @custom:scenario A user mints shares
+     * @custom:when 100 shares are minted for a user
+     * @custom:then The `Transfer` event should be emitted with the zero address as the sender, the user as the
+     * recipient, and the minted amount
+     * @custom:and The user's token balance should match the minted amount
+     */
+    function test_mintShares() public {
+        vm.expectEmit(address(usdn));
+        emit Transfer(address(0), USER_1, 100 ether);
+        usdn.mint(address(this), 100 ether);
+
+        assertEq(usdn.balanceOf(address(this)), 100 ether, "balance of user");
+        assertEq(usdn.sharesOf(address(this)), 100 ether, "shares of user");
+    }
+}

--- a/test/unit/UsdnNoRebase/Permit.t.sol
+++ b/test/unit/UsdnNoRebase/Permit.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { PermitSigUtils } from "../../utils/PermitSigUtils.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `permit` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ * @custom:and A user `alice` with a private key
+ */
+contract TestUsdnNoRebasePermit is UsdnNoRebaseTokenFixture {
+    PermitSigUtils internal sigUtils;
+    uint256 internal userPrivateKey;
+    address internal user;
+
+    function setUp() public override {
+        super.setUp();
+        sigUtils = new PermitSigUtils(usdn.DOMAIN_SEPARATOR());
+        (user, userPrivateKey) = makeAddrAndKey("alice");
+        usdn.mint(user, 100 ether);
+    }
+
+    /**
+     * @custom:scenario Getting the domain separator
+     * @custom:when The domain separator is retrieved
+     * @custom:then The domain separator is equal to the expected value
+     */
+    function test_domainSeparator() public view {
+        bytes32 typeHash =
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        assertEq(
+            usdn.DOMAIN_SEPARATOR(),
+            keccak256(
+                abi.encode(typeHash, keccak256(bytes("NAME")), keccak256(bytes("1")), block.chainid, address(usdn))
+            )
+        );
+    }
+
+    /**
+     * @custom:scenario Permitting a spender
+     * @custom:given Alice has signed a permit for this contract to spend 100 tokens
+     * @custom:when This contract calls the `permit` function with the signature of Alice
+     * @custom:then The `Approval` event is emitted with Alice as the owner, this contract as the spender and amount 100
+     * tokens
+     * @custom:and The allowance of Alice for this contract is 100 tokens
+     * @custom:and The nonce of Alice is incremented
+     */
+    function test_permit() public {
+        uint256 nonce = usdn.nonces(user);
+
+        PermitSigUtils.Permit memory permit = PermitSigUtils.Permit({
+            owner: user,
+            spender: address(this),
+            value: 100 ether,
+            nonce: nonce,
+            deadline: type(uint256).max
+        });
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPrivateKey, digest);
+
+        vm.expectEmit(address(usdn));
+        emit Approval(user, address(this), 100 ether); // expected event
+        usdn.permit(user, address(this), 100 ether, type(uint256).max, v, r, s);
+        assertEq(usdn.allowance(user, address(this)), 100 ether, "allowance");
+        assertEq(usdn.nonces(user), nonce + 1, "nonce");
+    }
+
+    /**
+     * @custom:scenario Transferring tokens with a permit
+     * @custom:given Alice has signed a permit for this contract to spend 100 tokens
+     * @custom:and This contract has used the signature to get an allowance of 100 tokens
+     * @custom:when This contract calls the `transferFrom` function with Alice as the sender, another user as the
+     * recipient and amount 100 tokens
+     * @custom:then The `Transfer` event is emitted with Alice as the sender, the other user as the recipient and amount
+     * 100 tokens
+     * @custom:and The allowance of Alice for this contract is zero
+     */
+    function test_permitTransfer() public {
+        uint256 nonce = usdn.nonces(user);
+
+        PermitSigUtils.Permit memory permit = PermitSigUtils.Permit({
+            owner: user,
+            spender: address(this),
+            value: 100 ether,
+            nonce: nonce,
+            deadline: type(uint256).max
+        });
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPrivateKey, digest);
+        usdn.permit(user, address(this), 100 ether, type(uint256).max, v, r, s);
+
+        // transfer from
+        vm.expectEmit(address(usdn));
+        emit Transfer(user, USER_1, 100 ether); // expected event
+        usdn.transferFrom(user, USER_1, 100 ether);
+
+        assertEq(usdn.allowance(user, address(this)), 0);
+    }
+
+    /**
+     * @custom:scenario Permitting a spender with a deadline
+     * @custom:given Alice has signed a permit for this contract to spend 100 tokens with a timestamp in the past
+     * @custom:when This contract calls the `permit` function with the signature of Alice
+     * @custom:then The transaction reverts with the `ERC2612ExpiredSignature` error
+     */
+    function test_RevertWhen_signatureIsOutdated() public {
+        uint256 nonce = usdn.nonces(user);
+
+        PermitSigUtils.Permit memory permit = PermitSigUtils.Permit({
+            owner: user,
+            spender: address(this),
+            value: 100 ether,
+            nonce: nonce,
+            deadline: block.timestamp - 1
+        });
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPrivateKey, digest);
+
+        vm.expectRevert(abi.encodeWithSelector(ERC2612ExpiredSignature.selector, block.timestamp - 1));
+        usdn.permit(user, address(this), 100 ether, block.timestamp - 1, v, r, s);
+    }
+
+    /**
+     * @custom:scenario Permitting a spender with an invalid signature
+     * @custom:given Bob has signed a permit for this contract to spend 100 of Alice's tokens
+     * @custom:when This contract calls the `permit` function with the signature of Bob
+     * @custom:then The transaction reverts with the `ERC2612InvalidSignature` error
+     */
+    function test_RevertWhen_invalidSigner() public {
+        PermitSigUtils.Permit memory permit = PermitSigUtils.Permit({
+            owner: user,
+            spender: address(this),
+            value: 100 ether,
+            nonce: 0,
+            deadline: type(uint256).max
+        });
+        bytes32 digest = sigUtils.getTypedDataHash(permit);
+        (address bob, uint256 bobPrivateKey) = makeAddrAndKey("bob");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(bobPrivateKey, digest);
+
+        vm.expectRevert(abi.encodeWithSelector(ERC2612InvalidSigner.selector, bob, user));
+        usdn.permit(user, address(this), 100 ether, type(uint256).max, v, r, s);
+    }
+}

--- a/test/unit/UsdnNoRebase/Rebase.t.sol
+++ b/test/unit/UsdnNoRebase/Rebase.t.sol
@@ -31,10 +31,10 @@ contract TestUsdnNoRebaseRebase is UsdnNoRebaseTokenFixture {
     }
 
     /**
-     * @custom:scenario Rebase by adjusting the divisor
+     * @custom:scenario A call to the rebase function should not do anything
      * @custom:given A user with 100 USDN
      * @custom:and This contract is the owner
-     * @custom:when The divisor is adjusted to MAX_DIVISOR / 10
+     * @custom:when The `rebase` function is called
      * @custom:then No event is emitted
      * @custom:and the total supply of tokens and shares do not change
      */

--- a/test/unit/UsdnNoRebase/Rebase.t.sol
+++ b/test/unit/UsdnNoRebase/Rebase.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { Vm } from "forge-std/Vm.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `rebase` function of `UsdnNoRebase`
+ * @custom:background Given the current divisor is MAX_DIVISOR
+ */
+contract TestUsdnNoRebaseRebase is UsdnNoRebaseTokenFixture {
+    uint256 internal maxDivisor;
+
+    function setUp() public override {
+        super.setUp();
+        maxDivisor = usdn.MAX_DIVISOR();
+        uint256 minDivisor = usdn.MIN_DIVISOR();
+        assertEq(minDivisor, maxDivisor, "The max and min divisor must be equal in a no rebase setup");
+        assertEq(usdn.maxTokens(), type(uint256).max, "There should not be a max amount of tokens in a no rebase setup");
+    }
+
+    /**
+     * @custom:scenario Getting the divisor
+     * @custom:when The `divisor` function is called
+     * @custom:then The result is MAX_DIVISOR
+     */
+    function test_getDivisor() public view {
+        assertEq(usdn.divisor(), maxDivisor);
+    }
+
+    /**
+     * @custom:scenario Rebase by adjusting the divisor
+     * @custom:given A user with 100 USDN
+     * @custom:and This contract is the owner
+     * @custom:when The divisor is adjusted to MAX_DIVISOR / 10
+     * @custom:then No event is emitted
+     * @custom:and the total supply of tokens and shares do not change
+     */
+    function test_rebase() public {
+        usdn.mint(USER_1, 100 ether);
+
+        uint256 totalSupplyBefore = usdn.totalSupply();
+        uint256 totalSharesBefore = usdn.totalShares();
+        vm.recordLogs();
+        (bool rebased, uint256 oldDivisor, bytes memory callbackResult) = usdn.rebase(maxDivisor / 10);
+        assertEq(vm.getRecordedLogs().length, 0, "No logs should have been emitted");
+
+        assertFalse(rebased, "No rebase should have happened");
+        assertEq(oldDivisor, maxDivisor, "divisor should not have changed");
+        assertEq(callbackResult, bytes(""), "No callback should have been called");
+
+        // supply changes
+        assertEq(totalSupplyBefore, usdn.totalSupply(), "Total supply should not have changed");
+        assertEq(totalSharesBefore, usdn.totalShares(), "Total shares should not have changed");
+    }
+}

--- a/test/unit/UsdnNoRebase/SetRebaseHandler.t.sol
+++ b/test/unit/UsdnNoRebase/SetRebaseHandler.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+import { IRebaseCallback } from "../../../src/interfaces/Usdn/IRebaseCallback.sol";
+
+/**
+ * @custom:feature The `setRebaseHandler` function of `UsdnNoRebase`
+ * @custom:background Given this contract is the owner
+ */
+contract TestUsdnNoRebaseSetRebaseHandler is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        assertEq(address(usdn.rebaseHandler()), address(0), "The rebase handler cannot be set in a no rebase setup");
+    }
+
+    /**
+     * @custom:scenario Update the rebase handler
+     * @custom:when `setRebaseHandler` is called
+     * @custom:then The call reverts with a `UsdnRebaseNotSupported` error
+     */
+    function test_RevertWhen_setRebaseHandler() public {
+        vm.expectRevert(UsdnRebaseNotSupported.selector);
+        usdn.setRebaseHandler(IRebaseCallback(address(0)));
+    }
+}

--- a/test/unit/UsdnNoRebase/TransferShares.t.sol
+++ b/test/unit/UsdnNoRebase/TransferShares.t.sol
@@ -30,7 +30,7 @@ contract TestUsdnNoRebaseTransferShares is UsdnNoRebaseTokenFixture {
 
     /**
      * @custom:scenario Transfer shares to another user with insufficient balance
-     * @custom:when We try to transfer 100 ether shares to user 1
+     * @custom:when We try to transfer 150 ether shares to user 1
      * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
      */
     function test_RevertWhen_transferSharesInsufficientBalance() public {

--- a/test/unit/UsdnNoRebase/TransferShares.t.sol
+++ b/test/unit/UsdnNoRebase/TransferShares.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `transferShares` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ */
+contract TestUsdnNoRebaseTransferShares is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        usdn.mint(address(this), 100 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares to another user
+     * @custom:when 100 shares are transfer from a user to the contract
+     * @custom:then The `Transfer` event should be emitted with the sender address as the sender,
+     * the contract address as the recipient, and the corresponding amount
+     */
+    function test_transferShares() public {
+        vm.expectEmit(address(usdn));
+        emit Transfer(address(this), USER_1, 100 ether);
+        usdn.transferShares(USER_1, 100 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares to another user with insufficient balance
+     * @custom:when We try to transfer 100 ether shares to user 1
+     * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
+     */
+    function test_RevertWhen_transferSharesInsufficientBalance() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, address(this), 100 ether, 150 ether)
+        );
+        usdn.transferShares(USER_1, 150 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares to the zero address
+     * @custom:when We try to transfer shares to the zero address
+     * @custom:then The transaction reverts with the `ERC20InvalidReceiver` error
+     */
+    function test_RevertWhen_transferSharesToZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InvalidReceiver.selector, address(0)));
+        usdn.transferShares(address(0), 100 ether);
+    }
+}

--- a/test/unit/UsdnNoRebase/TransferSharesFrom.t.sol
+++ b/test/unit/UsdnNoRebase/TransferSharesFrom.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+import { USER_1 } from "../../utils/Constants.sol";
+import { UsdnNoRebaseTokenFixture } from "./utils/Fixtures.sol";
+
+/**
+ * @custom:feature The `transferSharesFrom` function of `UsdnNoRebase`
+ * @custom:background Given a user with 100 tokens
+ */
+contract TestUsdnNoRebaseTransferSharesFrom is UsdnNoRebaseTokenFixture {
+    function setUp() public override {
+        super.setUp();
+        usdn.mint(USER_1, 100 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares from a user to another user
+     * @custom:when 100 shares are transfer from a user to the contract
+     * @custom:then The `Transfer` event should be emitted with the sender address as the sender,
+     * the contract address as the recipient, and the corresponding amount
+     */
+    function test_transferSharesFrom() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), type(uint256).max);
+
+        uint256 sharesAmount = 100 ether;
+
+        // conversion checks
+        uint256 tokenAmount = usdn.convertToTokens(sharesAmount);
+        assertEq(tokenAmount, sharesAmount, "1 share == 1 token in a no rebase setup");
+        assertEq(tokenAmount, usdn.convertToTokensRoundUp(sharesAmount), "1 share == 1 token in a no rebase setup");
+        assertEq(sharesAmount, usdn.convertToShares(tokenAmount), "1 share == 1 token in a no rebase setup");
+
+        vm.expectEmit(address(usdn));
+        emit Transfer(USER_1, address(this), 100 ether);
+        usdn.transferSharesFrom(USER_1, address(this), 100 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares from a user to another user with insufficient balance
+     * @custom:when We try to transfer 100 ether shares from user 1 to this address
+     * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
+     */
+    function test_RevertWhen_transferSharesInsufficientBalance() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), type(uint256).max);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, USER_1, 100 ether, 150 ether)
+        );
+        usdn.transferSharesFrom(USER_1, address(this), 150 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares from another user to zero address
+     * @custom:given User 1 has approved this contract to transfer their tokens
+     * @custom:when We try to transfer user 1's shares to the zero address
+     * @custom:then The transaction reverts with the `ERC20InvalidReceiver` error
+     */
+    function test_RevertWhen_transferSharesFromToZeroAddress() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), type(uint256).max);
+
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InvalidReceiver.selector, address(0)));
+        usdn.transferSharesFrom(USER_1, address(0), 100 ether);
+    }
+
+    /**
+     * @custom:scenario Transfer shares from another user with insufficient allowance
+     * @custom:given User 1 has approved this contract to transfer 1 wei of their tokens
+     * @custom:when We try to transfer 100e18 shares from user 1 to this contract
+     * @custom:then The transaction reverts with the `ERC20InsufficientAllowance` error
+     */
+    function test_RevertWhen_transferSharesFromExceedsAllowance() public {
+        vm.prank(USER_1);
+        usdn.approve(address(this), 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(this), 1, 100 ether)
+        );
+        usdn.transferSharesFrom(USER_1, address(this), 100 ether);
+    }
+}

--- a/test/unit/UsdnNoRebase/TransferSharesFrom.t.sol
+++ b/test/unit/UsdnNoRebase/TransferSharesFrom.t.sol
@@ -41,7 +41,7 @@ contract TestUsdnNoRebaseTransferSharesFrom is UsdnNoRebaseTokenFixture {
 
     /**
      * @custom:scenario Transfer shares from a user to another user with insufficient balance
-     * @custom:when We try to transfer 100 ether shares from user 1 to this address
+     * @custom:when We try to transfer 150 ether shares from user 1 to this address
      * @custom:then The transaction reverts with the `ERC20InsufficientBalance` error
      */
     function test_RevertWhen_transferSharesInsufficientBalance() public {

--- a/test/unit/UsdnNoRebase/utils/Fixtures.sol
+++ b/test/unit/UsdnNoRebase/utils/Fixtures.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.26;
 
+import { UsdnNoRebase } from "../../../../src/Usdn/UsdnNoRebase.sol";
 import { BaseFixture } from "../../../utils/Fixtures.sol";
 import { IEventsErrors } from "../../../utils/IEventsErrors.sol";
-import { UsdnHandler } from "./Handler.sol";
 
 import { IUsdnErrors } from "../../../../src/interfaces/Usdn/IUsdnErrors.sol";
 import { IUsdnEvents } from "../../../../src/interfaces/Usdn/IUsdnEvents.sol";
@@ -12,10 +12,10 @@ import { IUsdnEvents } from "../../../../src/interfaces/Usdn/IUsdnEvents.sol";
  * @title UsdnTokenFixture
  * @dev Utils for testing Usdn.sol
  */
-contract UsdnTokenFixture is BaseFixture, IEventsErrors, IUsdnEvents, IUsdnErrors {
-    UsdnHandler public usdn;
+contract UsdnNoRebaseTokenFixture is BaseFixture, IEventsErrors, IUsdnEvents, IUsdnErrors {
+    UsdnNoRebase public usdn;
 
     function setUp() public virtual {
-        usdn = new UsdnHandler();
+        usdn = new UsdnNoRebase("NAME", "SYMBOL");
     }
 }


### PR DESCRIPTION
This PR aims to add a version of the USDN token that does not rebase.
Therefore, most of the functionalities where striiped down to the basic ERC20 implementation while still implementing the `IUSDN` interface:
* 1 share == 1 token
* divisor is always 1
* `rebaseHandler` is always `address(0)`
* `setRebaseHandler` always reverts
* `transferShares` and `transferSharesFrom` simply use `transfer` and `transferFrom`
* `totalShares` == `totalSupply`

Closes RA2BL-622