### PR TITLE
feat: new liquidation rewards manager for short DN

### DIFF
--- a/script/01_DeployUsdnWsteth.s.sol
+++ b/script/01_DeployUsdnWsteth.s.sol
@@ -10,7 +10,7 @@ import { FixedPointMathLib } from "solady/src/utils/FixedPointMathLib.sol";
 import { UsdnWstethConfig } from "./deploymentConfigs/UsdnWstethConfig.sol";
 import { Utils } from "./utils/Utils.s.sol";
 
-import { LiquidationRewardsManager } from "../src/LiquidationRewardsManager/LiquidationRewardsManager.sol";
+import { LiquidationRewardsManagerWsteth } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
 import { WstEthOracleMiddleware } from "../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Rebalancer } from "../src/Rebalancer/Rebalancer.sol";
 import { Usdn } from "../src/Usdn/Usdn.sol";
@@ -45,7 +45,7 @@ contract DeployUsdnWsteth is UsdnWstethConfig, Script {
         external
         returns (
             WstEthOracleMiddleware wstEthOracleMiddleware_,
-            LiquidationRewardsManager liquidationRewardsManager_,
+            LiquidationRewardsManagerWsteth liquidationRewardsManager_,
             Rebalancer rebalancer_,
             Usdn usdn_,
             Wusdn wusdn_,
@@ -79,13 +79,13 @@ contract DeployUsdnWsteth is UsdnWstethConfig, Script {
         internal
         returns (
             WstEthOracleMiddleware wstEthOracleMiddleware_,
-            LiquidationRewardsManager liquidationRewardsManager_,
+            LiquidationRewardsManagerWsteth liquidationRewardsManager_,
             Usdn usdn_,
             Wusdn wusdn_
         )
     {
         vm.startBroadcast();
-        liquidationRewardsManager_ = new LiquidationRewardsManager(WSTETH);
+        liquidationRewardsManager_ = new LiquidationRewardsManagerWsteth(WSTETH);
         wstEthOracleMiddleware_ = new WstEthOracleMiddleware(
             PYTH_ADDRESS, PYTH_ETH_FEED_ID, CHAINLINK_ETH_PRICE, address(WSTETH), CHAINLINK_PRICE_VALIDITY
         );

--- a/script/01_DeployUsdnWsteth.s.sol
+++ b/script/01_DeployUsdnWsteth.s.sol
@@ -10,7 +10,7 @@ import { FixedPointMathLib } from "solady/src/utils/FixedPointMathLib.sol";
 import { UsdnWstethConfig } from "./deploymentConfigs/UsdnWstethConfig.sol";
 import { Utils } from "./utils/Utils.s.sol";
 
-import { LiquidationRewardsManagerWsteth } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
+import { LiquidationRewardsManagerWstEth } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 import { WstEthOracleMiddleware } from "../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Rebalancer } from "../src/Rebalancer/Rebalancer.sol";
 import { Usdn } from "../src/Usdn/Usdn.sol";
@@ -45,7 +45,7 @@ contract DeployUsdnWsteth is UsdnWstethConfig, Script {
         external
         returns (
             WstEthOracleMiddleware wstEthOracleMiddleware_,
-            LiquidationRewardsManagerWsteth liquidationRewardsManager_,
+            LiquidationRewardsManagerWstEth liquidationRewardsManager_,
             Rebalancer rebalancer_,
             Usdn usdn_,
             Wusdn wusdn_,
@@ -79,13 +79,13 @@ contract DeployUsdnWsteth is UsdnWstethConfig, Script {
         internal
         returns (
             WstEthOracleMiddleware wstEthOracleMiddleware_,
-            LiquidationRewardsManagerWsteth liquidationRewardsManager_,
+            LiquidationRewardsManagerWstEth liquidationRewardsManager_,
             Usdn usdn_,
             Wusdn wusdn_
         )
     {
         vm.startBroadcast();
-        liquidationRewardsManager_ = new LiquidationRewardsManagerWsteth(WSTETH);
+        liquidationRewardsManager_ = new LiquidationRewardsManagerWstEth(WSTETH);
         wstEthOracleMiddleware_ = new WstEthOracleMiddleware(
             PYTH_ADDRESS, PYTH_ETH_FEED_ID, CHAINLINK_ETH_PRICE, address(WSTETH), CHAINLINK_PRICE_VALIDITY
         );

--- a/script/99_DeployProtocolFork.s.sol
+++ b/script/99_DeployProtocolFork.s.sol
@@ -12,7 +12,7 @@ import { WstETH } from "../test/utils/WstEth.sol";
 
 import { Utils } from "./utils/Utils.s.sol";
 
-import { LiquidationRewardsManager } from "../src/LiquidationRewardsManager/LiquidationRewardsManager.sol";
+import { LiquidationRewardsManagerWsteth } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
 import { WstEthOracleMiddleware } from "../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { MockWstEthOracleMiddleware } from "../src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol";
 import { Rebalancer } from "../src/Rebalancer/Rebalancer.sol";
@@ -61,7 +61,7 @@ contract DeployProtocol is Script {
             WstETH WstETH_,
             Sdex Sdex_,
             WstEthOracleMiddleware WstEthOracleMiddleware_,
-            LiquidationRewardsManager LiquidationRewardsManager_,
+            LiquidationRewardsManagerWsteth LiquidationRewardsManager_,
             Rebalancer Rebalancer_,
             Usdn Usdn_,
             Wusdn Wusdn_,
@@ -175,14 +175,14 @@ contract DeployProtocol is Script {
      */
     function _deployLiquidationRewardsManager(address wstETHAddress)
         internal
-        returns (LiquidationRewardsManager liquidationRewardsManager_)
+        returns (LiquidationRewardsManagerWsteth liquidationRewardsManager_)
     {
         address liquidationRewardsManagerAddress = vm.envOr("LIQUIDATION_REWARDS_MANAGER_ADDRESS", address(0));
 
         if (liquidationRewardsManagerAddress != address(0)) {
-            liquidationRewardsManager_ = LiquidationRewardsManager(liquidationRewardsManagerAddress);
+            liquidationRewardsManager_ = LiquidationRewardsManagerWsteth(liquidationRewardsManagerAddress);
         } else {
-            liquidationRewardsManager_ = new LiquidationRewardsManager(IWstETH(wstETHAddress));
+            liquidationRewardsManager_ = new LiquidationRewardsManagerWsteth(IWstETH(wstETHAddress));
         }
     }
 
@@ -331,7 +331,7 @@ contract DeployProtocol is Script {
         IUsdnProtocol usdnProtocol,
         Rebalancer rebalancer,
         WstEthOracleMiddleware wstEthOracleMiddleware,
-        LiquidationRewardsManager liquidationRewardsManager
+        LiquidationRewardsManagerWsteth liquidationRewardsManager
     ) internal {
         // grant the necessary roles to the deployer to set the rebalancer and then revoke them
         bytes32 ADMIN_SET_EXTERNAL_ROLE = Constants.ADMIN_SET_EXTERNAL_ROLE;

--- a/script/99_DeployProtocolFork.s.sol
+++ b/script/99_DeployProtocolFork.s.sol
@@ -12,7 +12,7 @@ import { WstETH } from "../test/utils/WstEth.sol";
 
 import { Utils } from "./utils/Utils.s.sol";
 
-import { LiquidationRewardsManagerWsteth } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
+import { LiquidationRewardsManagerWstEth } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 import { WstEthOracleMiddleware } from "../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { MockWstEthOracleMiddleware } from "../src/OracleMiddleware/mock/MockWstEthOracleMiddleware.sol";
 import { Rebalancer } from "../src/Rebalancer/Rebalancer.sol";
@@ -61,7 +61,7 @@ contract DeployProtocol is Script {
             WstETH WstETH_,
             Sdex Sdex_,
             WstEthOracleMiddleware WstEthOracleMiddleware_,
-            LiquidationRewardsManagerWsteth LiquidationRewardsManager_,
+            LiquidationRewardsManagerWstEth LiquidationRewardsManager_,
             Rebalancer Rebalancer_,
             Usdn Usdn_,
             Wusdn Wusdn_,
@@ -175,14 +175,14 @@ contract DeployProtocol is Script {
      */
     function _deployLiquidationRewardsManager(address wstETHAddress)
         internal
-        returns (LiquidationRewardsManagerWsteth liquidationRewardsManager_)
+        returns (LiquidationRewardsManagerWstEth liquidationRewardsManager_)
     {
         address liquidationRewardsManagerAddress = vm.envOr("LIQUIDATION_REWARDS_MANAGER_ADDRESS", address(0));
 
         if (liquidationRewardsManagerAddress != address(0)) {
-            liquidationRewardsManager_ = LiquidationRewardsManagerWsteth(liquidationRewardsManagerAddress);
+            liquidationRewardsManager_ = LiquidationRewardsManagerWstEth(liquidationRewardsManagerAddress);
         } else {
-            liquidationRewardsManager_ = new LiquidationRewardsManagerWsteth(IWstETH(wstETHAddress));
+            liquidationRewardsManager_ = new LiquidationRewardsManagerWstEth(IWstETH(wstETHAddress));
         }
     }
 
@@ -331,7 +331,7 @@ contract DeployProtocol is Script {
         IUsdnProtocol usdnProtocol,
         Rebalancer rebalancer,
         WstEthOracleMiddleware wstEthOracleMiddleware,
-        LiquidationRewardsManagerWsteth liquidationRewardsManager
+        LiquidationRewardsManagerWstEth liquidationRewardsManager
     ) internal {
         // grant the necessary roles to the deployer to set the rebalancer and then revoke them
         bytes32 ADMIN_SET_EXTERNAL_ROLE = Constants.ADMIN_SET_EXTERNAL_ROLE;

--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -57,9 +57,9 @@ abstract contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownab
         uint256 currentPrice,
         bool rebased,
         Types.RebalancerAction rebalancerAction,
-        Types.ProtocolAction,
-        bytes calldata,
-        bytes calldata
+        Types.ProtocolAction action,
+        bytes calldata rebaseCallbackResult,
+        bytes calldata priceData
     ) external view virtual returns (uint256 rewards_);
 
     /// @inheritdoc ILiquidationRewardsManager

--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { FixedPointMathLib } from "solady/src/utils/FixedPointMathLib.sol";
 
-import { IWstETH } from "../interfaces/IWstETH.sol";
 import { IBaseLiquidationRewardsManager } from
     "../interfaces/LiquidationRewardsManager/IBaseLiquidationRewardsManager.sol";
 import { ILiquidationRewardsManager } from "../interfaces/LiquidationRewardsManager/ILiquidationRewardsManager.sol";
@@ -16,7 +15,7 @@ import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnPro
  * @notice This contract calculates rewards for liquidators within the USDN protocol.
  * @dev Rewards are computed based on gas costs, position size, and other parameters.
  */
-contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
+abstract contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
     /* -------------------------------------------------------------------------- */
     /*                                  Constants                                 */
     /* -------------------------------------------------------------------------- */
@@ -43,30 +42,14 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
     /*                              Storage Variables                             */
     /* -------------------------------------------------------------------------- */
 
-    /// @notice The address of the wrapped stETH (wstETH) token contract.
-    IWstETH private immutable _wstEth;
+    /// @notice The address of the reward asset.
+    IERC20 internal immutable _rewardAsset;
 
     /**
      * @notice Holds the parameters used for rewards calculation.
      * @dev Parameters should be updated to reflect changes in gas costs or protocol adjustments.
      */
-    RewardsParameters private _rewardsParameters;
-
-    /// @param wstETH The address of the wstETH token.
-    constructor(IWstETH wstETH) Ownable(msg.sender) {
-        _wstEth = wstETH;
-        _rewardsParameters = RewardsParameters({
-            gasUsedPerTick: 53_094,
-            otherGasUsed: 469_537,
-            rebaseGasUsed: 13_765,
-            rebalancerGasUsed: 279_349,
-            baseFeeOffset: 2 gwei,
-            gasMultiplierBps: 10_500, // 1.05
-            positionBonusMultiplierBps: 200, // 0.02
-            fixedReward: 0.001 ether,
-            maxReward: 0.5 ether
-        });
-    }
+    RewardsParameters internal _rewardsParameters;
 
     /// @inheritdoc IBaseLiquidationRewardsManager
     function getLiquidationRewards(
@@ -77,37 +60,7 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
         Types.ProtocolAction,
         bytes calldata,
         bytes calldata
-    ) external view returns (uint256 wstETHRewards_) {
-        if (liquidatedTicks.length == 0) {
-            return 0;
-        }
-
-        RewardsParameters memory rewardsParameters = _rewardsParameters;
-        // calculate the amount of gas spent during the liquidation
-        uint256 gasUsed = rewardsParameters.otherGasUsed + BASE_GAS_COST
-            + uint256(rewardsParameters.gasUsedPerTick) * liquidatedTicks.length;
-        if (rebased) {
-            gasUsed += rewardsParameters.rebaseGasUsed;
-        }
-        if (uint8(rebalancerAction) > uint8(Types.RebalancerAction.NoCloseNoOpen)) {
-            gasUsed += rewardsParameters.rebalancerGasUsed;
-        }
-
-        uint256 totalRewardETH = rewardsParameters.fixedReward
-            + _calcGasPrice(rewardsParameters.baseFeeOffset) * gasUsed * rewardsParameters.gasMultiplierBps / BPS_DIVISOR;
-
-        uint256 wstEthBonus =
-            _calcPositionSizeBonus(liquidatedTicks, currentPrice, rewardsParameters.positionBonusMultiplierBps);
-
-        totalRewardETH += _wstEth.getStETHByWstETH(wstEthBonus);
-
-        if (totalRewardETH > rewardsParameters.maxReward) {
-            totalRewardETH = rewardsParameters.maxReward;
-        }
-
-        // convert to wstETH
-        wstETHRewards_ = _wstEth.getWstETHByStETH(totalRewardETH);
-    }
+    ) external view virtual returns (uint256 rewards_);
 
     /// @inheritdoc ILiquidationRewardsManager
     function getRewardsParameters() external view returns (RewardsParameters memory) {
@@ -178,7 +131,7 @@ contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
      * @param liquidatedTicks Information about the liquidated ticks.
      * @param currentPrice The current asset price.
      * @param multiplier The bonus multiplier (in BPS).
-     * @return bonus_ The calculated bonus (in wstETH).
+     * @return bonus_ The calculated bonus (in _rewardAsset).
      */
     function _calcPositionSizeBonus(
         Types.LiqTickInfo[] calldata liquidatedTicks,

--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -12,8 +12,8 @@ import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnPro
 
 /**
  * @title Liquidation Rewards Manager
- * @notice This abstract contract calculates rewards for liquidators within the USDN protocol.
- * @dev Rewards are computed based on gas costs, position size, and other parameters.
+ * @dev This abstract contract calculates the bonus portion of the rewards based on the size of the liquidated ticks.
+ * The actual reward calculation is left to the implementing contract.
  */
 abstract contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
     /* -------------------------------------------------------------------------- */

--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -12,7 +12,7 @@ import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnPro
 
 /**
  * @title Liquidation Rewards Manager
- * @notice This contract calculates rewards for liquidators within the USDN protocol.
+ * @notice This abstract contract calculates rewards for liquidators within the USDN protocol.
  * @dev Rewards are computed based on gas costs, position size, and other parameters.
  */
 abstract contract LiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol
@@ -16,7 +16,7 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
  * between wstETH and stETH, assuming a one-to-one rate between stETH and ETH. Additionally a fixed reward is added
  * along with a bonus based on the size of the liquidated ticks.
  */
-contract LiquidationRewardsManagerWsteth is LiquidationRewardsManager {
+contract LiquidationRewardsManagerWstEth is LiquidationRewardsManager {
     /// @param wstETH The address of the wstETH token.
     constructor(IWstETH wstETH) Ownable(msg.sender) {
         _rewardAsset = wstETH;

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol
@@ -11,8 +11,10 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
 
 /**
  * @title Liquidation Rewards Manager for Wrapped stETH
- * @notice This contract calculates rewards for liquidators within the USDN protocol with wstETH as underlying asset.
- * @dev Rewards are computed based on gas costs, position size, and other parameters.
+ * @notice This contract calculates rewards for liquidators within the USDN protocol, using wstETH as the underlying
+ * asset. Rewards are computed based on gas costs, which are converted to wstETH using the current conversion rate
+ * between wstETH and stETH, assuming a one-to-one rate between stETH and ETH. Additionally a fixed reward is added
+ * along with a bonus based on the size of the liquidated ticks.
  */
 contract LiquidationRewardsManagerWsteth is LiquidationRewardsManager {
     /// @param wstETH The address of the wstETH token.

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol
@@ -10,8 +10,8 @@ import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnPro
 import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
 
 /**
- * @title Liquidation Rewards Manager
- * @notice This contract calculates rewards for liquidators within the USDN protocol.
+ * @title Liquidation Rewards Manager for Wrapped stETH
+ * @notice This contract calculates rewards for liquidators within the USDN protocol with wstETH as underlying asset.
  * @dev Rewards are computed based on gas costs, position size, and other parameters.
  */
 contract LiquidationRewardsManagerWsteth is LiquidationRewardsManager {

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -26,7 +26,7 @@ contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
         _rewardsParameters = RewardsParameters({
             gasUsedPerTick: 53_094,
             otherGasUsed: 469_537,
-            rebaseGasUsed: 13_765,
+            rebaseGasUsed: 0,
             rebalancerGasUsed: 279_349,
             baseFeeOffset: 2 gwei,
             gasMultiplierBps: 10_500, // 1.05
@@ -40,7 +40,7 @@ contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
     function getLiquidationRewards(
         Types.LiqTickInfo[] calldata liquidatedTicks,
         uint256 currentPrice,
-        bool rebased,
+        bool,
         Types.RebalancerAction rebalancerAction,
         Types.ProtocolAction,
         bytes calldata,
@@ -54,9 +54,6 @@ contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
         // calculate the amount of gas spent during the liquidation
         uint256 gasUsed = rewardsParameters.otherGasUsed + BASE_GAS_COST
             + uint256(rewardsParameters.gasUsedPerTick) * liquidatedTicks.length;
-        if (rebased) {
-            gasUsed += rewardsParameters.rebaseGasUsed;
-        }
         if (uint8(rebalancerAction) > uint8(Types.RebalancerAction.NoCloseNoOpen)) {
             gasUsed += rewardsParameters.rebalancerGasUsed;
         }

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -16,7 +16,7 @@ import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnPro
  * @notice This contract calculates rewards for liquidators within the USDN protocol.
  * @dev Rewards are computed based on gas costs, position size, and other parameters.
  */
-contract WusdnLiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
+contract LiquidationRewardsManagerWusdn is ILiquidationRewardsManager, Ownable2Step {
     /* -------------------------------------------------------------------------- */
     /*                                  Constants                                 */
     /* -------------------------------------------------------------------------- */
@@ -63,8 +63,8 @@ contract WusdnLiquidationRewardsManager is ILiquidationRewardsManager, Ownable2S
             baseFeeOffset: 2 gwei,
             gasMultiplierBps: 10_500, // 1.05
             positionBonusMultiplierBps: 200, // 0.02
-            fixedReward: 0.001 ether,
-            maxReward: 0.5 ether
+            fixedReward: 2 ether,
+            maxReward: 1000 ether
         });
     }
 

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -17,7 +17,7 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
  */
 contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
     /// @notice The precision used for the price.
-    uint256 public constant PRICE_DECIMALS = 1e18;
+    uint256 constant PRICE_DECIMALS = 1e18;
 
     /// @param wusdn The address of the wUsdn token.
     constructor(IWusdn wusdn) Ownable(msg.sender) {

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -12,8 +12,9 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
 
 /**
  * @title Liquidation Rewards Manager for Wrapped USDN
- * @notice This contract calculates rewards for liquidators within the USDN protocol with wUsdn as underlying asset.
- * @dev Rewards are computed based on gas costs, position size, and other parameters.
+ * @notice This contract calculates rewards for liquidators within the USDN protocol, using wUSDN as the underlying
+ * asset. Rewards are computed based on gas costs which are converted to wUSDN using the current price. Additionally a
+ * fixed reward is added along with a bonus based on the size of the liquidated ticks.
  */
 contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
     /// @notice The precision used for the price.

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -18,7 +18,7 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
  */
 contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
     /// @notice The precision used for the price.
-    uint256 constant PRICE_PRECISION = 1e18;
+    uint256 internal constant PRICE_PRECISION = 1e18;
 
     /// @param wusdn The address of the wUSDN token.
     constructor(IWusdn wusdn) Ownable(msg.sender) {

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -18,9 +18,9 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
  */
 contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
     /// @notice The precision used for the price.
-    uint256 constant PRICE_DECIMALS = 1e18;
+    uint256 constant PRICE_PRECISION = 1e18;
 
-    /// @param wusdn The address of the wUsdn token.
+    /// @param wusdn The address of the wUSDN token.
     constructor(IWusdn wusdn) Ownable(msg.sender) {
         _rewardAsset = wusdn;
         _rewardsParameters = RewardsParameters({
@@ -64,7 +64,7 @@ contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
         wUsdnRewards_ = rewardsParameters.fixedReward
             + _calcPositionSizeBonus(liquidatedTicks, currentPrice, rewardsParameters.positionBonusMultiplierBps);
 
-        wUsdnRewards_ += FixedPointMathLib.fullMulDiv(gasRewards, PRICE_DECIMALS, currentPrice);
+        wUsdnRewards_ += FixedPointMathLib.fullMulDiv(gasRewards, PRICE_PRECISION, currentPrice);
 
         if (wUsdnRewards_ > rewardsParameters.maxReward) {
             wUsdnRewards_ = rewardsParameters.maxReward;

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -11,8 +11,8 @@ import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnPro
 import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
 
 /**
- * @title Liquidation Rewards Manager
- * @notice This contract calculates rewards for liquidators within the USDN protocol.
+ * @title Liquidation Rewards Manager for Wrapped USDN
+ * @notice This contract calculates rewards for liquidators within the USDN protocol with wUsdn as underlying asset.
  * @dev Rewards are computed based on gas costs, position size, and other parameters.
  */
 contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { FixedPointMathLib } from "solady/src/utils/FixedPointMathLib.sol";
+
+import { IBaseLiquidationRewardsManager } from
+    "../interfaces/LiquidationRewardsManager/IBaseLiquidationRewardsManager.sol";
+import { ILiquidationRewardsManager } from "../interfaces/LiquidationRewardsManager/ILiquidationRewardsManager.sol";
+import { IWusdn } from "../interfaces/Usdn/IWusdn.sol";
+import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
+
+/**
+ * @title Liquidation Rewards Manager
+ * @notice This contract calculates rewards for liquidators within the USDN protocol.
+ * @dev Rewards are computed based on gas costs, position size, and other parameters.
+ */
+contract WusdnLiquidationRewardsManager is ILiquidationRewardsManager, Ownable2Step {
+    /* -------------------------------------------------------------------------- */
+    /*                                  Constants                                 */
+    /* -------------------------------------------------------------------------- */
+
+    /// @inheritdoc ILiquidationRewardsManager
+    uint32 public constant BPS_DIVISOR = 10_000;
+
+    /// @inheritdoc ILiquidationRewardsManager
+    uint256 public constant BASE_GAS_COST = 21_000;
+
+    /// @inheritdoc ILiquidationRewardsManager
+    uint256 public constant MAX_GAS_USED_PER_TICK = 500_000;
+
+    /// @inheritdoc ILiquidationRewardsManager
+    uint256 public constant MAX_OTHER_GAS_USED = 1_000_000;
+
+    /// @inheritdoc ILiquidationRewardsManager
+    uint256 public constant MAX_REBASE_GAS_USED = 200_000;
+
+    /// @inheritdoc ILiquidationRewardsManager
+    uint256 public constant MAX_REBALANCER_GAS_USED = 300_000;
+
+    /* -------------------------------------------------------------------------- */
+    /*                              Storage Variables                             */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice The address of the wrapped Usdn (wUsdn) token contract.
+    IWusdn private immutable _wusdn;
+
+    /**
+     * @notice Holds the parameters used for rewards calculation.
+     * @dev Parameters should be updated to reflect changes in gas costs or protocol adjustments.
+     */
+    RewardsParameters private _rewardsParameters;
+
+    /// @param wUsdn The address of the wUsdn token.
+    constructor(IWusdn wUsdn) Ownable(msg.sender) {
+        _wusdn = wUsdn;
+        _rewardsParameters = RewardsParameters({
+            gasUsedPerTick: 53_094,
+            otherGasUsed: 469_537,
+            rebaseGasUsed: 13_765,
+            rebalancerGasUsed: 279_349,
+            baseFeeOffset: 2 gwei,
+            gasMultiplierBps: 10_500, // 1.05
+            positionBonusMultiplierBps: 200, // 0.02
+            fixedReward: 0.001 ether,
+            maxReward: 0.5 ether
+        });
+    }
+
+    /// @inheritdoc IBaseLiquidationRewardsManager
+    function getLiquidationRewards(
+        Types.LiqTickInfo[] calldata liquidatedTicks,
+        uint256 currentPrice,
+        bool rebased,
+        Types.RebalancerAction rebalancerAction,
+        Types.ProtocolAction,
+        bytes calldata,
+        bytes calldata
+    ) external view returns (uint256 wstETHRewards_) {
+        if (liquidatedTicks.length == 0) {
+            return 0;
+        }
+
+        RewardsParameters memory rewardsParameters = _rewardsParameters;
+        // calculate the amount of gas spent during the liquidation
+        uint256 gasUsed = rewardsParameters.otherGasUsed + BASE_GAS_COST
+            + uint256(rewardsParameters.gasUsedPerTick) * liquidatedTicks.length;
+        if (rebased) {
+            gasUsed += rewardsParameters.rebaseGasUsed;
+        }
+        if (uint8(rebalancerAction) > uint8(Types.RebalancerAction.NoCloseNoOpen)) {
+            gasUsed += rewardsParameters.rebalancerGasUsed;
+        }
+
+        uint256 totalRewardETH = rewardsParameters.fixedReward
+            + _calcGasPrice(rewardsParameters.baseFeeOffset) * gasUsed * rewardsParameters.gasMultiplierBps / BPS_DIVISOR;
+
+        uint256 wstEthBonus =
+            _calcPositionSizeBonus(liquidatedTicks, currentPrice, rewardsParameters.positionBonusMultiplierBps);
+
+        // totalRewardETH += _wstEth.getStETHByWstETH(wstEthBonus);
+
+        if (totalRewardETH > rewardsParameters.maxReward) {
+            totalRewardETH = rewardsParameters.maxReward;
+        }
+
+        // convert to wstETH
+        // wstETHRewards_ = _wstEth.getWstETHByStETH(totalRewardETH);
+    }
+
+    /// @inheritdoc ILiquidationRewardsManager
+    function getRewardsParameters() external view returns (RewardsParameters memory) {
+        return _rewardsParameters;
+    }
+
+    /// @inheritdoc ILiquidationRewardsManager
+    function setRewardsParameters(
+        uint32 gasUsedPerTick,
+        uint32 otherGasUsed,
+        uint32 rebaseGasUsed,
+        uint32 rebalancerGasUsed,
+        uint64 baseFeeOffset,
+        uint16 gasMultiplierBps,
+        uint16 positionBonusMultiplierBps,
+        uint128 fixedReward,
+        uint128 maxReward
+    ) external onlyOwner {
+        if (gasUsedPerTick > MAX_GAS_USED_PER_TICK) {
+            revert LiquidationRewardsManagerGasUsedPerTickTooHigh(gasUsedPerTick);
+        } else if (otherGasUsed > MAX_OTHER_GAS_USED) {
+            revert LiquidationRewardsManagerOtherGasUsedTooHigh(otherGasUsed);
+        } else if (rebaseGasUsed > MAX_REBASE_GAS_USED) {
+            revert LiquidationRewardsManagerRebaseGasUsedTooHigh(rebaseGasUsed);
+        } else if (rebalancerGasUsed > MAX_REBALANCER_GAS_USED) {
+            revert LiquidationRewardsManagerRebalancerGasUsedTooHigh(rebalancerGasUsed);
+        }
+
+        _rewardsParameters = RewardsParameters({
+            gasUsedPerTick: gasUsedPerTick,
+            otherGasUsed: otherGasUsed,
+            rebaseGasUsed: rebaseGasUsed,
+            rebalancerGasUsed: rebalancerGasUsed,
+            baseFeeOffset: baseFeeOffset,
+            gasMultiplierBps: gasMultiplierBps,
+            positionBonusMultiplierBps: positionBonusMultiplierBps,
+            fixedReward: fixedReward,
+            maxReward: maxReward
+        });
+
+        emit RewardsParametersUpdated(
+            gasUsedPerTick,
+            otherGasUsed,
+            rebaseGasUsed,
+            rebalancerGasUsed,
+            baseFeeOffset,
+            gasMultiplierBps,
+            positionBonusMultiplierBps,
+            fixedReward,
+            maxReward
+        );
+    }
+
+    /**
+     * @notice Calculates the gas price used for rewards calculations.
+     * @param baseFeeOffset An offset added to the block's base gas fee.
+     * @return gasPrice_ The gas price used for reward calculation.
+     */
+    function _calcGasPrice(uint64 baseFeeOffset) internal view returns (uint256 gasPrice_) {
+        gasPrice_ = block.basefee + baseFeeOffset;
+        if (gasPrice_ > tx.gasprice) {
+            gasPrice_ = tx.gasprice;
+        }
+    }
+
+    /**
+     * @notice Computes the size and price-dependent bonus given for liquidating the ticks.
+     * @param liquidatedTicks Information about the liquidated ticks.
+     * @param currentPrice The current asset price.
+     * @param multiplier The bonus multiplier (in BPS).
+     * @return bonus_ The calculated bonus (in wstETH).
+     */
+    function _calcPositionSizeBonus(
+        Types.LiqTickInfo[] calldata liquidatedTicks,
+        uint256 currentPrice,
+        uint16 multiplier
+    ) internal pure returns (uint256 bonus_) {
+        uint256 length = liquidatedTicks.length;
+        uint256 i;
+        do {
+            if (currentPrice >= liquidatedTicks[i].tickPrice) {
+                // the currentPrice should never exceed the tick price, as a tick cannot be liquidated when the current
+                // price is greater than the tick price
+                // if this condition occurs, the bonus is clamped to 0
+                // additionally, when the `currentPrice` equals the tick price, the bonus is 0 by definition of the
+                // formula, so the calculation can be skipped
+                unchecked {
+                    i++;
+                }
+                continue;
+            }
+            uint256 priceDiff;
+            unchecked {
+                priceDiff = liquidatedTicks[i].tickPrice - currentPrice;
+            }
+            bonus_ += FixedPointMathLib.fullMulDiv(liquidatedTicks[i].totalExpo, priceDiff, currentPrice);
+            unchecked {
+                i++;
+            }
+        } while (i < length);
+        bonus_ = bonus_ * multiplier / BPS_DIVISOR;
+    }
+}

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -16,6 +16,9 @@ import { LiquidationRewardsManager } from "./LiquidationRewardsManager.sol";
  * @dev Rewards are computed based on gas costs, position size, and other parameters.
  */
 contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
+    /// @notice The precision used for the price.
+    uint256 public constant PRICE_DECIMALS = 1e18;
+
     /// @param wusdn The address of the wUsdn token.
     constructor(IWusdn wusdn) Ownable(msg.sender) {
         _rewardAsset = wusdn;
@@ -63,7 +66,7 @@ contract LiquidationRewardsManagerWusdn is LiquidationRewardsManager {
         wUsdnRewards_ = rewardsParameters.fixedReward
             + _calcPositionSizeBonus(liquidatedTicks, currentPrice, rewardsParameters.positionBonusMultiplierBps);
 
-        wUsdnRewards_ += FixedPointMathLib.fullMulDiv(gasRewards, BPS_DIVISOR, currentPrice);
+        wUsdnRewards_ += FixedPointMathLib.fullMulDiv(gasRewards, PRICE_DECIMALS, currentPrice);
 
         if (wUsdnRewards_ > rewardsParameters.maxReward) {
             wUsdnRewards_ = rewardsParameters.maxReward;

--- a/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol
@@ -77,7 +77,7 @@ contract WusdnLiquidationRewardsManager is ILiquidationRewardsManager, Ownable2S
         Types.ProtocolAction,
         bytes calldata,
         bytes calldata
-    ) external view returns (uint256 wstETHRewards_) {
+    ) external view returns (uint256 wUsdnRewards_) {
         if (liquidatedTicks.length == 0) {
             return 0;
         }
@@ -93,20 +93,17 @@ contract WusdnLiquidationRewardsManager is ILiquidationRewardsManager, Ownable2S
             gasUsed += rewardsParameters.rebalancerGasUsed;
         }
 
-        uint256 totalRewardETH = rewardsParameters.fixedReward
-            + _calcGasPrice(rewardsParameters.baseFeeOffset) * gasUsed * rewardsParameters.gasMultiplierBps / BPS_DIVISOR;
+        uint256 gasRewards =
+            _calcGasPrice(rewardsParameters.baseFeeOffset) * gasUsed * rewardsParameters.gasMultiplierBps / BPS_DIVISOR;
 
-        uint256 wstEthBonus =
-            _calcPositionSizeBonus(liquidatedTicks, currentPrice, rewardsParameters.positionBonusMultiplierBps);
+        wUsdnRewards_ = rewardsParameters.fixedReward
+            + _calcPositionSizeBonus(liquidatedTicks, currentPrice, rewardsParameters.positionBonusMultiplierBps);
 
-        // totalRewardETH += _wstEth.getStETHByWstETH(wstEthBonus);
+        wUsdnRewards_ += FixedPointMathLib.fullMulDiv(gasRewards, BPS_DIVISOR, currentPrice);
 
-        if (totalRewardETH > rewardsParameters.maxReward) {
-            totalRewardETH = rewardsParameters.maxReward;
+        if (wUsdnRewards_ > rewardsParameters.maxReward) {
+            wUsdnRewards_ = rewardsParameters.maxReward;
         }
-
-        // convert to wstETH
-        // wstETHRewards_ = _wstEth.getWstETHByStETH(totalRewardETH);
     }
 
     /// @inheritdoc ILiquidationRewardsManager

--- a/test/integration/UsdnProtocol/utils/Fixtures.sol
+++ b/test/integration/UsdnProtocol/utils/Fixtures.sol
@@ -32,7 +32,8 @@ import {
     PYTH_DATA_TIMESTAMP
 } from "../../Middlewares/utils/Constants.sol";
 
-import { LiquidationRewardsManager } from "../../../../src/LiquidationRewardsManager/LiquidationRewardsManager.sol";
+import { LiquidationRewardsManagerWsteth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Rebalancer } from "../../../../src/Rebalancer/Rebalancer.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
@@ -95,7 +96,7 @@ contract UsdnProtocolBaseIntegrationFixture is
     MockPyth public mockPyth;
     MockChainlinkOnChain public mockChainlinkOnChain;
     WstEthOracleMiddleware public oracleMiddleware;
-    LiquidationRewardsManager public liquidationRewardsManager;
+    LiquidationRewardsManagerWsteth public liquidationRewardsManager;
     Rebalancer public rebalancer;
 
     PreviousActionsData internal EMPTY_PREVIOUS_DATA =
@@ -149,7 +150,7 @@ contract UsdnProtocolBaseIntegrationFixture is
             PriceInfo memory currentPrice =
                 oracleMiddleware.parseAndValidatePrice("", uint128(block.timestamp), ProtocolAction.Initialize, "");
             testParams.initialLiqPrice = uint128(currentPrice.neutralPrice) / 2;
-            liquidationRewardsManager = new LiquidationRewardsManager(wstETH);
+            liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
         } else {
             wstETH = new WstETH();
             sdex = new Sdex();
@@ -164,7 +165,7 @@ contract UsdnProtocolBaseIntegrationFixture is
                 address(mockPyth), PYTH_ETH_USD, address(mockChainlinkOnChain), address(wstETH), 1 hours
             );
             vm.warp(testParams.initialTimestamp);
-            liquidationRewardsManager = new LiquidationRewardsManager(wstETH);
+            liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
         }
         (bool success,) = address(wstETH).call{ value: DEPLOYER.balance * 9 / 10 }("");
         require(success, "DEPLOYER wstETH mint failed");

--- a/test/integration/UsdnProtocol/utils/Fixtures.sol
+++ b/test/integration/UsdnProtocol/utils/Fixtures.sol
@@ -32,8 +32,8 @@ import {
     PYTH_DATA_TIMESTAMP
 } from "../../Middlewares/utils/Constants.sol";
 
-import { LiquidationRewardsManagerWsteth } from
-    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
+import { LiquidationRewardsManagerWstEth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Rebalancer } from "../../../../src/Rebalancer/Rebalancer.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
@@ -96,7 +96,7 @@ contract UsdnProtocolBaseIntegrationFixture is
     MockPyth public mockPyth;
     MockChainlinkOnChain public mockChainlinkOnChain;
     WstEthOracleMiddleware public oracleMiddleware;
-    LiquidationRewardsManagerWsteth public liquidationRewardsManager;
+    LiquidationRewardsManagerWstEth public liquidationRewardsManager;
     Rebalancer public rebalancer;
 
     PreviousActionsData internal EMPTY_PREVIOUS_DATA =
@@ -150,7 +150,7 @@ contract UsdnProtocolBaseIntegrationFixture is
             PriceInfo memory currentPrice =
                 oracleMiddleware.parseAndValidatePrice("", uint128(block.timestamp), ProtocolAction.Initialize, "");
             testParams.initialLiqPrice = uint128(currentPrice.neutralPrice) / 2;
-            liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
+            liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wstETH);
         } else {
             wstETH = new WstETH();
             sdex = new Sdex();
@@ -165,7 +165,7 @@ contract UsdnProtocolBaseIntegrationFixture is
                 address(mockPyth), PYTH_ETH_USD, address(mockChainlinkOnChain), address(wstETH), 1 hours
             );
             vm.warp(testParams.initialTimestamp);
-            liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
+            liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wstETH);
         }
         (bool success,) = address(wstETH).call{ value: DEPLOYER.balance * 9 / 10 }("");
         require(success, "DEPLOYER wstETH mint failed");

--- a/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
+++ b/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
@@ -55,6 +55,7 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
      * @custom:then It should return an amount of wUsdn based on the gas used by UsdnProtocolActions.liquidate(bytes)
      */
     function test_getLiquidationRewardsFor1Tick() public view {
+        uint256 priceDecimals = liquidationRewardsManager.PRICE_DECIMALS();
         uint256 posBonusWusdn = (
             _singleLiquidatedTick[0].totalExpo * (_singleLiquidatedTick[0].tickPrice - CURRENT_PRICE) / CURRENT_PRICE
         ) * 200 / BPS_DIVISOR;
@@ -65,7 +66,7 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
         uint256 gasUsed = rewardsParameters.otherGasUsed + liquidationRewardsManager.BASE_GAS_COST()
             + uint256(rewardsParameters.gasUsedPerTick) * _singleLiquidatedTick.length;
         uint256 totRewards = rewardsParameters.fixedReward + posBonusWusdn
-            + gasUsed * gasPriceAndMultiplier * BPS_DIVISOR / CURRENT_PRICE;
+            + gasUsed * gasPriceAndMultiplier * priceDecimals / CURRENT_PRICE;
         uint256 rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick, CURRENT_PRICE, false, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
         );
@@ -73,7 +74,7 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
 
         gasUsed += rewardsParameters.rebaseGasUsed;
         totRewards = rewardsParameters.fixedReward + posBonusWusdn
-            + gasUsed * gasPriceAndMultiplier * BPS_DIVISOR / CURRENT_PRICE;
+            + gasUsed * gasPriceAndMultiplier * priceDecimals / CURRENT_PRICE;
         rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick, CURRENT_PRICE, true, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
         );
@@ -81,7 +82,7 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
 
         gasUsed += rewardsParameters.rebalancerGasUsed;
         totRewards = rewardsParameters.fixedReward + posBonusWusdn
-            + gasUsed * gasPriceAndMultiplier * BPS_DIVISOR / CURRENT_PRICE;
+            + gasUsed * gasPriceAndMultiplier * priceDecimals / CURRENT_PRICE;
         rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick,
             CURRENT_PRICE,

--- a/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
+++ b/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
@@ -28,7 +28,7 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
         liquidationRewardsManager = new LiquidationRewardsManagerWusdn(wusdn);
 
         liquidationRewardsManager.setRewardsParameters(
-            50_000, 500_000, 10_000, 300_000, 2 gwei, 10_500, 200, 2 ether, 1000 ether
+            50_000, 500_000, 0, 300_000, 2 gwei, 10_500, 200, 2 ether, 1000 ether
         );
 
         rewardsParameters = liquidationRewardsManager.getRewardsParameters();

--- a/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
+++ b/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
@@ -69,15 +69,7 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
         uint256 rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick, CURRENT_PRICE, false, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
         );
-        assertEq(rewards, totRewards, "without rebase");
-
-        gasUsed += rewardsParameters.rebaseGasUsed;
-        totRewards =
-            rewardsParameters.fixedReward + posBonusWusdn + gasUsed * gasPriceAndMultiplier * 1e18 / CURRENT_PRICE;
-        rewards = liquidationRewardsManager.getLiquidationRewards(
-            _singleLiquidatedTick, CURRENT_PRICE, true, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
-        );
-        assertEq(rewards, totRewards, "with rebase");
+        assertEq(rewards, totRewards, "without rebalancer trigger");
 
         gasUsed += rewardsParameters.rebalancerGasUsed;
         totRewards =

--- a/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
+++ b/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.26;
 
-import { LiquidationRewardsManagerWusdn } from
-    "../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol";
 import { BaseFixture } from "../../utils/Fixtures.sol";
 
+import { LiquidationRewardsManagerWusdn } from
+    "../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol";
 import { Usdn } from "../../../src/Usdn/Usdn.sol";
 import { Wusdn } from "../../../src/Usdn/Wusdn.sol";
 import { ILiquidationRewardsManagerErrorsEventsTypes } from
@@ -13,20 +13,17 @@ import { IWusdn } from "../../../src/interfaces/Usdn/IWusdn.sol";
 import { IUsdnProtocolTypes as Types } from "../../../src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
 
 /// @custom:feature The `getLiquidationRewards` function of `LiquidationRewardsManagerWusdn`
-
 contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture {
     IWusdn internal wusdn;
     LiquidationRewardsManagerWusdn internal liquidationRewardsManager;
     ILiquidationRewardsManagerErrorsEventsTypes.RewardsParameters rewardsParameters;
 
-    uint256 internal constant CURRENT_PRICE = 0.98 ether / 1000; // 0.001 eth/wUsdn
+    uint256 internal constant CURRENT_PRICE = 1 ether / 1000; // 0.001 eth/wUsdn
 
     Types.LiqTickInfo[] internal _singleLiquidatedTick;
     Types.LiqTickInfo[] internal _liquidatedTicksEmpty;
 
     function setUp() public {
-        vm.warp(1_704_063_600); // 01/01/2024 @ 12:00am (UTC+2)
-
         wusdn = new Wusdn(new Usdn(address(0), address(0)));
         liquidationRewardsManager = new LiquidationRewardsManagerWusdn(wusdn);
 
@@ -53,11 +50,9 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
     /**
      * @custom:scenario Call `getLiquidationRewards` when 1 tick was liquidated
      * @custom:given The tx.gasprice is equal to the base fee + offset
-     * @custom:and The exchange rate for stETH per wstETH is 1.15
-     * @custom:and The current price of wstETH is $1000
+     * @custom:and The current price of is 0.001 eth/wUsdn
      * @custom:when 1 tick was liquidated
-     * @custom:then It should return an amount of wstETH based on the gas used by
-     * UsdnProtocolActions.liquidate(bytes)
+     * @custom:then It should return an amount of wUsdn based on the gas used by UsdnProtocolActions.liquidate(bytes)
      */
     function test_getLiquidationRewardsFor1Tick() public view {
         uint256 posBonusWusdn = (

--- a/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
+++ b/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
@@ -55,7 +55,6 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
      * @custom:then It should return an amount of wUsdn based on the gas used by UsdnProtocolActions.liquidate(bytes)
      */
     function test_getLiquidationRewardsFor1Tick() public view {
-        uint256 priceDecimals = liquidationRewardsManager.PRICE_DECIMALS();
         uint256 posBonusWusdn = (
             _singleLiquidatedTick[0].totalExpo * (_singleLiquidatedTick[0].tickPrice - CURRENT_PRICE) / CURRENT_PRICE
         ) * 200 / BPS_DIVISOR;
@@ -65,24 +64,24 @@ contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture 
 
         uint256 gasUsed = rewardsParameters.otherGasUsed + liquidationRewardsManager.BASE_GAS_COST()
             + uint256(rewardsParameters.gasUsedPerTick) * _singleLiquidatedTick.length;
-        uint256 totRewards = rewardsParameters.fixedReward + posBonusWusdn
-            + gasUsed * gasPriceAndMultiplier * priceDecimals / CURRENT_PRICE;
+        uint256 totRewards =
+            rewardsParameters.fixedReward + posBonusWusdn + gasUsed * gasPriceAndMultiplier * 1e18 / CURRENT_PRICE;
         uint256 rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick, CURRENT_PRICE, false, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
         );
         assertEq(rewards, totRewards, "without rebase");
 
         gasUsed += rewardsParameters.rebaseGasUsed;
-        totRewards = rewardsParameters.fixedReward + posBonusWusdn
-            + gasUsed * gasPriceAndMultiplier * priceDecimals / CURRENT_PRICE;
+        totRewards =
+            rewardsParameters.fixedReward + posBonusWusdn + gasUsed * gasPriceAndMultiplier * 1e18 / CURRENT_PRICE;
         rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick, CURRENT_PRICE, true, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
         );
         assertEq(rewards, totRewards, "with rebase");
 
         gasUsed += rewardsParameters.rebalancerGasUsed;
-        totRewards = rewardsParameters.fixedReward + posBonusWusdn
-            + gasUsed * gasPriceAndMultiplier * priceDecimals / CURRENT_PRICE;
+        totRewards =
+            rewardsParameters.fixedReward + posBonusWusdn + gasUsed * gasPriceAndMultiplier * 1e18 / CURRENT_PRICE;
         rewards = liquidationRewardsManager.getLiquidationRewards(
             _singleLiquidatedTick,
             CURRENT_PRICE,

--- a/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
+++ b/test/unit/LiquidationRewardsManager/GetLiquidationRewardsWusdn.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { LiquidationRewardsManagerWusdn } from
+    "../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol";
+import { BaseFixture } from "../../utils/Fixtures.sol";
+
+import { Usdn } from "../../../src/Usdn/Usdn.sol";
+import { Wusdn } from "../../../src/Usdn/Wusdn.sol";
+import { ILiquidationRewardsManagerErrorsEventsTypes } from
+    "../../../src/interfaces/LiquidationRewardsManager/ILiquidationRewardsManagerErrorsEventsTypes.sol";
+import { IWusdn } from "../../../src/interfaces/Usdn/IWusdn.sol";
+import { IUsdnProtocolTypes as Types } from "../../../src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
+
+/// @custom:feature The `getLiquidationRewards` function of `LiquidationRewardsManagerWusdn`
+
+contract TestLiquidationRewardsManagerWusdnGetLiquidationRewards is BaseFixture {
+    IWusdn internal wusdn;
+    LiquidationRewardsManagerWusdn internal liquidationRewardsManager;
+    ILiquidationRewardsManagerErrorsEventsTypes.RewardsParameters rewardsParameters;
+
+    uint256 internal constant CURRENT_PRICE = 0.98 ether / 1000; // 0.001 eth/wUsdn
+
+    Types.LiqTickInfo[] internal _singleLiquidatedTick;
+    Types.LiqTickInfo[] internal _liquidatedTicksEmpty;
+
+    function setUp() public {
+        vm.warp(1_704_063_600); // 01/01/2024 @ 12:00am (UTC+2)
+
+        wusdn = new Wusdn(new Usdn(address(0), address(0)));
+        liquidationRewardsManager = new LiquidationRewardsManagerWusdn(wusdn);
+
+        liquidationRewardsManager.setRewardsParameters(
+            50_000, 500_000, 10_000, 300_000, 2 gwei, 10_500, 200, 2 ether, 1000 ether
+        );
+
+        rewardsParameters = liquidationRewardsManager.getRewardsParameters();
+
+        vm.fee(30 gwei);
+        vm.txGasPrice(40 gwei);
+
+        _singleLiquidatedTick.push(
+            Types.LiqTickInfo({
+                totalPositions: 1,
+                totalExpo: 10_000 ether,
+                remainingCollateral: -200 ether,
+                tickPrice: 1.02 ether / 1000, // 0.00102 eth/wUsdn
+                priceWithoutPenalty: 1 ether / 1000 // 0.001 eth/wUsdn
+             })
+        );
+    }
+
+    /**
+     * @custom:scenario Call `getLiquidationRewards` when 1 tick was liquidated
+     * @custom:given The tx.gasprice is equal to the base fee + offset
+     * @custom:and The exchange rate for stETH per wstETH is 1.15
+     * @custom:and The current price of wstETH is $1000
+     * @custom:when 1 tick was liquidated
+     * @custom:then It should return an amount of wstETH based on the gas used by
+     * UsdnProtocolActions.liquidate(bytes)
+     */
+    function test_getLiquidationRewardsFor1Tick() public view {
+        uint256 posBonusWusdn = (
+            _singleLiquidatedTick[0].totalExpo * (_singleLiquidatedTick[0].tickPrice - CURRENT_PRICE) / CURRENT_PRICE
+        ) * 200 / BPS_DIVISOR;
+
+        uint256 gasPriceAndMultiplier =
+            (rewardsParameters.baseFeeOffset + block.basefee) * rewardsParameters.gasMultiplierBps / BPS_DIVISOR;
+
+        uint256 gasUsed = rewardsParameters.otherGasUsed + liquidationRewardsManager.BASE_GAS_COST()
+            + uint256(rewardsParameters.gasUsedPerTick) * _singleLiquidatedTick.length;
+        uint256 totRewards = rewardsParameters.fixedReward + posBonusWusdn
+            + gasUsed * gasPriceAndMultiplier * BPS_DIVISOR / CURRENT_PRICE;
+        uint256 rewards = liquidationRewardsManager.getLiquidationRewards(
+            _singleLiquidatedTick, CURRENT_PRICE, false, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
+        );
+        assertEq(rewards, totRewards, "without rebase");
+
+        gasUsed += rewardsParameters.rebaseGasUsed;
+        totRewards = rewardsParameters.fixedReward + posBonusWusdn
+            + gasUsed * gasPriceAndMultiplier * BPS_DIVISOR / CURRENT_PRICE;
+        rewards = liquidationRewardsManager.getLiquidationRewards(
+            _singleLiquidatedTick, CURRENT_PRICE, true, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
+        );
+        assertEq(rewards, totRewards, "with rebase");
+
+        gasUsed += rewardsParameters.rebalancerGasUsed;
+        totRewards = rewardsParameters.fixedReward + posBonusWusdn
+            + gasUsed * gasPriceAndMultiplier * BPS_DIVISOR / CURRENT_PRICE;
+        rewards = liquidationRewardsManager.getLiquidationRewards(
+            _singleLiquidatedTick,
+            CURRENT_PRICE,
+            true,
+            Types.RebalancerAction.ClosedOpened,
+            Types.ProtocolAction.None,
+            "",
+            ""
+        );
+        assertEq(rewards, totRewards, "with rebalancer trigger");
+    }
+
+    /**
+     * @custom:scenario Call `getLiquidationRewards` when 0 ticks were liquidated
+     * @custom:when No ticks were liquidated
+     * @custom:then It should return 0 as we only give rewards on successful liquidations
+     */
+    function test_getLiquidationRewardsFor0Tick() public view {
+        uint256 rewards = liquidationRewardsManager.getLiquidationRewards(
+            _liquidatedTicksEmpty, CURRENT_PRICE, false, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
+        );
+        assertEq(rewards, 0, "without rebase");
+        rewards = liquidationRewardsManager.getLiquidationRewards(
+            _liquidatedTicksEmpty, CURRENT_PRICE, true, Types.RebalancerAction.None, Types.ProtocolAction.None, "", ""
+        );
+        assertEq(rewards, 0, "with rebase");
+        rewards = liquidationRewardsManager.getLiquidationRewards(
+            _liquidatedTicksEmpty,
+            CURRENT_PRICE,
+            false,
+            Types.RebalancerAction.ClosedOpened,
+            Types.ProtocolAction.None,
+            "",
+            ""
+        );
+        assertEq(rewards, 0, "with rebalancer trigger");
+    }
+}

--- a/test/unit/LiquidationRewardsManager/utils/Fixtures.sol
+++ b/test/unit/LiquidationRewardsManager/utils/Fixtures.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.26;
 import { BaseFixture } from "../../../utils/Fixtures.sol";
 import { WstETH } from "../../../utils/WstEth.sol";
 
-import { LiquidationRewardsManager } from "../../../../src/LiquidationRewardsManager/LiquidationRewardsManager.sol";
-import { IWstETH } from "../../../../src/interfaces/IWstETH.sol";
+import { LiquidationRewardsManagerWsteth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
 
 /**
  * @title LiquidationRewardsManagerBaseFixture
@@ -13,12 +13,12 @@ import { IWstETH } from "../../../../src/interfaces/IWstETH.sol";
  */
 contract LiquidationRewardsManagerBaseFixture is BaseFixture {
     WstETH internal wsteth;
-    LiquidationRewardsManager internal liquidationRewardsManager;
+    LiquidationRewardsManagerWsteth internal liquidationRewardsManager;
 
     function setUp() public virtual {
         vm.warp(1_704_063_600); // 01/01/2024 @ 12:00am (UTC+2)
 
         wsteth = new WstETH();
-        liquidationRewardsManager = new LiquidationRewardsManager(IWstETH(address(wsteth)));
+        liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wsteth);
     }
 }

--- a/test/unit/LiquidationRewardsManager/utils/Fixtures.sol
+++ b/test/unit/LiquidationRewardsManager/utils/Fixtures.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.26;
 import { BaseFixture } from "../../../utils/Fixtures.sol";
 import { WstETH } from "../../../utils/WstEth.sol";
 
-import { LiquidationRewardsManagerWsteth } from
-    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
+import { LiquidationRewardsManagerWstEth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 
 /**
  * @title LiquidationRewardsManagerBaseFixture
@@ -13,12 +13,12 @@ import { LiquidationRewardsManagerWsteth } from
  */
 contract LiquidationRewardsManagerBaseFixture is BaseFixture {
     WstETH internal wsteth;
-    LiquidationRewardsManagerWsteth internal liquidationRewardsManager;
+    LiquidationRewardsManagerWstEth internal liquidationRewardsManager;
 
     function setUp() public virtual {
         vm.warp(1_704_063_600); // 01/01/2024 @ 12:00am (UTC+2)
 
         wsteth = new WstETH();
-        liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wsteth);
+        liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wsteth);
     }
 }

--- a/test/unit/Rebalancer/utils/Fixtures.sol
+++ b/test/unit/Rebalancer/utils/Fixtures.sol
@@ -12,7 +12,8 @@ import { WstETH } from "../../../utils/WstEth.sol";
 import { MockOracleMiddleware } from "../../UsdnProtocol/utils/MockOracleMiddleware.sol";
 import { RebalancerHandler } from "../utils/Handler.sol";
 
-import { LiquidationRewardsManager } from "../../../../src/LiquidationRewardsManager/LiquidationRewardsManager.sol";
+import { LiquidationRewardsManagerWsteth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
@@ -39,7 +40,7 @@ contract RebalancerFixture is
     Sdex public sdex;
     WstETH public wstETH;
     MockOracleMiddleware public oracleMiddleware;
-    LiquidationRewardsManager public liquidationRewardsManager;
+    LiquidationRewardsManagerWsteth public liquidationRewardsManager;
     RebalancerHandler public rebalancer;
     IUsdnProtocol public usdnProtocol;
     Types.PreviousActionsData internal EMPTY_PREVIOUS_DATA =
@@ -51,7 +52,7 @@ contract RebalancerFixture is
         wstETH = new WstETH();
         sdex = new Sdex();
         oracleMiddleware = new MockOracleMiddleware();
-        liquidationRewardsManager = new LiquidationRewardsManager(wstETH);
+        liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
 
         UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback();
         UsdnProtocolImpl implementation = new UsdnProtocolImpl();

--- a/test/unit/Rebalancer/utils/Fixtures.sol
+++ b/test/unit/Rebalancer/utils/Fixtures.sol
@@ -12,8 +12,8 @@ import { WstETH } from "../../../utils/WstEth.sol";
 import { MockOracleMiddleware } from "../../UsdnProtocol/utils/MockOracleMiddleware.sol";
 import { RebalancerHandler } from "../utils/Handler.sol";
 
-import { LiquidationRewardsManagerWsteth } from
-    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
+import { LiquidationRewardsManagerWstEth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
@@ -40,7 +40,7 @@ contract RebalancerFixture is
     Sdex public sdex;
     WstETH public wstETH;
     MockOracleMiddleware public oracleMiddleware;
-    LiquidationRewardsManagerWsteth public liquidationRewardsManager;
+    LiquidationRewardsManagerWstEth public liquidationRewardsManager;
     RebalancerHandler public rebalancer;
     IUsdnProtocol public usdnProtocol;
     Types.PreviousActionsData internal EMPTY_PREVIOUS_DATA =
@@ -52,7 +52,7 @@ contract RebalancerFixture is
         wstETH = new WstETH();
         sdex = new Sdex();
         oracleMiddleware = new MockOracleMiddleware();
-        liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
+        liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wstETH);
 
         UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback();
         UsdnProtocolImpl implementation = new UsdnProtocolImpl();

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -15,7 +15,8 @@ import { RebalancerHandler } from "../../Rebalancer/utils/Handler.sol";
 import { UsdnProtocolHandler } from "./Handler.sol";
 import { MockOracleMiddleware } from "./MockOracleMiddleware.sol";
 
-import { LiquidationRewardsManager } from "../../../../src/LiquidationRewardsManager/LiquidationRewardsManager.sol";
+import { LiquidationRewardsManagerWsteth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
@@ -99,7 +100,7 @@ contract UsdnProtocolBaseFixture is
     Sdex public sdex;
     WstETH public wstETH;
     MockOracleMiddleware public oracleMiddleware;
-    LiquidationRewardsManager public liquidationRewardsManager;
+    LiquidationRewardsManagerWsteth public liquidationRewardsManager;
     RebalancerHandler public rebalancer;
     UsdnProtocolHandler public protocol;
     FeeCollector public feeCollector;
@@ -124,7 +125,7 @@ contract UsdnProtocolBaseFixture is
         wstETH = new WstETH();
         sdex = new Sdex();
         oracleMiddleware = new MockOracleMiddleware();
-        liquidationRewardsManager = new LiquidationRewardsManager(wstETH);
+        liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
         feeCollector = new FeeCollector();
 
         if (!testParams.flags.enableLiquidationRewards) {

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -15,8 +15,8 @@ import { RebalancerHandler } from "../../Rebalancer/utils/Handler.sol";
 import { UsdnProtocolHandler } from "./Handler.sol";
 import { MockOracleMiddleware } from "./MockOracleMiddleware.sol";
 
-import { LiquidationRewardsManagerWsteth } from
-    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWsteth.sol";
+import { LiquidationRewardsManagerWstEth } from
+    "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
@@ -100,7 +100,7 @@ contract UsdnProtocolBaseFixture is
     Sdex public sdex;
     WstETH public wstETH;
     MockOracleMiddleware public oracleMiddleware;
-    LiquidationRewardsManagerWsteth public liquidationRewardsManager;
+    LiquidationRewardsManagerWstEth public liquidationRewardsManager;
     RebalancerHandler public rebalancer;
     UsdnProtocolHandler public protocol;
     FeeCollector public feeCollector;
@@ -125,7 +125,7 @@ contract UsdnProtocolBaseFixture is
         wstETH = new WstETH();
         sdex = new Sdex();
         oracleMiddleware = new MockOracleMiddleware();
-        liquidationRewardsManager = new LiquidationRewardsManagerWsteth(wstETH);
+        liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wstETH);
         feeCollector = new FeeCollector();
 
         if (!testParams.flags.enableLiquidationRewards) {


### PR DESCRIPTION
This PR adds a liquidation rewards manager for the Short DN protocol. The rewards manager's role is to calculate the amount to send to the liquidator in wUSDN based on gas costs, position size, and other parameters.
An abstract contract was created to contain all similar code between the wstETH and wUUSDN versions.

Closes RA2BL-670.