### PR TITLE
ci: pin lintspec version

### DIFF
--- a/.github/workflows/natspec.yml
+++ b/.github/workflows/natspec.yml
@@ -17,6 +17,7 @@ jobs:
         uses: beeb/lintspec@main
         with:
           fail-on-problem: "false" # we handle failure manually to be able to trigger the notification
+          version: "0.3.0"
       - name: Fail on findings
         if: ${{ steps.lintspec-action.outputs.total-diags > 0 }}
         run: exit 1


### PR DESCRIPTION
Because a new breaking version was released, the CI would fail to parse the config file.

When the new version is available on nixpkgs, this version and the config file will be updated.