### PR TITLE
feat: remove the MAX_MIN_LONG_POSITION constant

### DIFF
--- a/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
@@ -103,9 +103,6 @@ library UsdnProtocolConstantsLibrary {
     /// @notice Maximum security deposit allowed.
     uint256 internal constant MAX_SECURITY_DEPOSIT = 5 ether;
 
-    /// @notice The highest value allowed for the minimum long position setting.
-    uint256 internal constant MAX_MIN_LONG_POSITION = 10 ether;
-
     /// @notice Maximum protocol fee allowed in basis points.
     uint16 internal constant MAX_PROTOCOL_FEE_BPS = 3000;
 

--- a/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
@@ -316,10 +316,6 @@ library UsdnProtocolSettersLibrary {
     function setMinLongPosition(uint256 newMinLongPosition) external {
         Types.Storage storage s = Utils._getMainStorage();
 
-        if (newMinLongPosition > Constants.MAX_MIN_LONG_POSITION) {
-            revert IUsdnProtocolErrors.UsdnProtocolInvalidMinLongPosition();
-        }
-
         s._minLongPosition = newMinLongPosition;
         emit IUsdnProtocolEvents.MinLongPositionUpdated(newMinLongPosition);
 

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolImpl.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolImpl.sol
@@ -4,11 +4,7 @@ pragma solidity >=0.8.0;
 import { IAccessControlDefaultAdminRules } from
     "@openzeppelin/contracts/access/extensions/IAccessControlDefaultAdminRules.sol";
 import { IERC5267 } from "@openzeppelin/contracts/interfaces/IERC5267.sol";
-import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { IBaseLiquidationRewardsManager } from "../LiquidationRewardsManager/IBaseLiquidationRewardsManager.sol";
-import { IBaseOracleMiddleware } from "../OracleMiddleware/IBaseOracleMiddleware.sol";
-import { IUsdn } from "../Usdn/IUsdn.sol";
 import { IUsdnProtocolActions } from "./IUsdnProtocolActions.sol";
 import { IUsdnProtocolCore } from "./IUsdnProtocolCore.sol";
 import { IUsdnProtocolFallback } from "./IUsdnProtocolFallback.sol";

--- a/test/unit/UsdnProtocol/Admin.t.sol
+++ b/test/unit/UsdnProtocol/Admin.t.sol
@@ -948,17 +948,6 @@ contract TestUsdnProtocolAdmin is UsdnProtocolBaseFixture, IRebalancerEvents {
     }
 
     /**
-     * @custom:scenario Call "setMinLongPosition" from admin
-     * @custom:given The initial usdnProtocol state
-     * @custom:when Admin wallet triggers the function with a value above the limit
-     * @custom:then The transaction should revert with the corresponding error
-     */
-    function test_RevertWhen_invalidSetMinLongPosition() public adminPrank {
-        vm.expectRevert(UsdnProtocolInvalidMinLongPosition.selector);
-        protocol.setMinLongPosition(10 ether + 1);
-    }
-
-    /**
      * @custom:scenario Call `setPositionFeeBps` as admin
      * @custom:when The admin sets the position fee between 0 and 2000 bps
      * @custom:then The position fee should be updated


### PR DESCRIPTION
The hard limit for the `minLongPosition` variable makes the protocol incompatible with a lot of underlying assets, as its value depends solely on the value of the asset compared to the ETH token (as the the min value of a long position depends on the gas used by a liquidation)