### PR TITLE
feat!: set asset bound setters limits on deployment

### DIFF
--- a/script/01_DeployUsdnWsteth.s.sol
+++ b/script/01_DeployUsdnWsteth.s.sol
@@ -108,8 +108,7 @@ contract DeployUsdnWsteth is UsdnWstethConfig, Script {
 
         vm.startBroadcast();
 
-        UsdnProtocolFallback protocolFallback =
-            new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION_AMOUNT);
+        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
         _setProtocolFallback(protocolFallback);
 
         address proxy = Upgrades.deployUUPSProxy(

--- a/script/01_DeployUsdnWsteth.s.sol
+++ b/script/01_DeployUsdnWsteth.s.sol
@@ -108,7 +108,8 @@ contract DeployUsdnWsteth is UsdnWstethConfig, Script {
 
         vm.startBroadcast();
 
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback();
+        UsdnProtocolFallback protocolFallback =
+            new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION_AMOUNT);
         _setProtocolFallback(protocolFallback);
 
         address proxy = Upgrades.deployUUPSProxy(

--- a/script/deploymentConfigs/UsdnWstethConfig.sol
+++ b/script/deploymentConfigs/UsdnWstethConfig.sol
@@ -21,7 +21,7 @@ contract UsdnWstethConfig is DeploymentConfig {
     uint256 constant CHAINLINK_GAS_PRICE_VALIDITY = 2 hours + 5 minutes;
     uint256 constant CHAINLINK_PRICE_VALIDITY = 1 hours + 2 minutes;
     uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
-    uint256 constant MAX_MIN_LONG_POSITION_AMOUNT = 10 ether;
+    uint256 constant MAX_MIN_LONG_POSITION = 10 ether;
 
     constructor() {
         INITIAL_LONG_AMOUNT = 200 ether;

--- a/script/deploymentConfigs/UsdnWstethConfig.sol
+++ b/script/deploymentConfigs/UsdnWstethConfig.sol
@@ -20,6 +20,8 @@ contract UsdnWstethConfig is DeploymentConfig {
     bytes32 constant PYTH_ETH_FEED_ID = 0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
     uint256 constant CHAINLINK_GAS_PRICE_VALIDITY = 2 hours + 5 minutes;
     uint256 constant CHAINLINK_PRICE_VALIDITY = 1 hours + 2 minutes;
+    uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
+    uint256 constant MAX_MIN_LONG_POSITION_AMOUNT = 10 ether;
 
     constructor() {
         INITIAL_LONG_AMOUNT = 200 ether;

--- a/src/UsdnProtocol/UsdnProtocolFallback.sol
+++ b/src/UsdnProtocol/UsdnProtocolFallback.sol
@@ -36,6 +36,21 @@ contract UsdnProtocolFallback is
 {
     using SafeTransferLib for address;
 
+    /// @notice The highest value allowed for the ratio of SDEX to burn per minted USDN on deposit.
+    uint256 internal immutable MAX_SDEX_BURN_RATIO;
+
+    /// @notice The highest value allowed for the minimum long position setting
+    uint256 internal immutable MAX_MIN_LONG_POSITION;
+
+    /**
+     * @param maxSdexBurnRatio The value of `MAX_SDEX_BURN_RATIO`.
+     * @param maxMinLongPosition The value of `MAX_MIN_LONG_POSITION`.
+     */
+    constructor(uint256 maxSdexBurnRatio, uint256 maxMinLongPosition) {
+        MAX_SDEX_BURN_RATIO = maxSdexBurnRatio;
+        MAX_MIN_LONG_POSITION = maxMinLongPosition;
+    }
+
     /// @inheritdoc IUsdnProtocolFallback
     function getActionablePendingActions(address currentUser, uint256 lookAhead, uint256 maxIter)
         external
@@ -576,7 +591,7 @@ contract UsdnProtocolFallback is
 
     /// @inheritdoc IUsdnProtocolFallback
     function setSdexBurnOnDepositRatio(uint32 newRatio) external onlyRole(Constants.SET_PROTOCOL_PARAMS_ROLE) {
-        Setters.setSdexBurnOnDepositRatio(newRatio);
+        Setters.setSdexBurnOnDepositRatio(MAX_SDEX_BURN_RATIO, newRatio);
     }
 
     /// @inheritdoc IUsdnProtocolFallback
@@ -608,7 +623,7 @@ contract UsdnProtocolFallback is
 
     /// @inheritdoc IUsdnProtocolFallback
     function setMinLongPosition(uint256 newMinLongPosition) external onlyRole(Constants.SET_PROTOCOL_PARAMS_ROLE) {
-        Setters.setMinLongPosition(newMinLongPosition);
+        Setters.setMinLongPosition(MAX_MIN_LONG_POSITION, newMinLongPosition);
     }
 
     /* -------------------------------------------------------------------------- */

--- a/src/UsdnProtocol/UsdnProtocolFallback.sol
+++ b/src/UsdnProtocol/UsdnProtocolFallback.sol
@@ -39,7 +39,7 @@ contract UsdnProtocolFallback is
     /// @notice The highest value allowed for the ratio of SDEX to burn per minted USDN on deposit.
     uint256 internal immutable MAX_SDEX_BURN_RATIO;
 
-    /// @notice The highest value allowed for the minimum long position setting
+    /// @notice The highest value allowed for the minimum long position setting.
     uint256 internal immutable MAX_MIN_LONG_POSITION;
 
     /**

--- a/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
@@ -94,9 +94,6 @@ library UsdnProtocolConstantsLibrary {
     /// @notice Maximum ratio of SDEX rewards allowed in basis points.
     uint256 internal constant MAX_SDEX_REWARDS_RATIO_BPS = 1000;
 
-    /// @notice Maximum ratio of SDEX to burn per minted USDN on deposit (10%).
-    uint256 internal constant MAX_SDEX_BURN_RATIO = SDEX_BURN_ON_DEPOSIT_DIVISOR / 10;
-
     /// @notice Maximum leverage allowed.
     uint256 internal constant MAX_LEVERAGE = 100 * 10 ** LEVERAGE_DECIMALS;
 

--- a/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol
@@ -103,9 +103,6 @@ library UsdnProtocolConstantsLibrary {
     /// @notice Maximum security deposit allowed.
     uint256 internal constant MAX_SECURITY_DEPOSIT = 5 ether;
 
-    /// @notice The highest value allowed for the minimum long position setting.
-    uint256 internal constant MAX_MIN_LONG_POSITION = 10 ether;
-
     /// @notice Maximum protocol fee allowed in basis points.
     uint16 internal constant MAX_PROTOCOL_FEE_BPS = 3000;
 

--- a/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
@@ -316,10 +316,6 @@ library UsdnProtocolSettersLibrary {
     function setMinLongPosition(uint256 newMinLongPosition) external {
         Types.Storage storage s = Utils._getMainStorage();
 
-        if (newMinLongPosition > Constants.MAX_MIN_LONG_POSITION) {
-            revert IUsdnProtocolErrors.UsdnProtocolInvalidMinLongPosition();
-        }
-
         s._minLongPosition = newMinLongPosition;
         emit IUsdnProtocolEvents.MinLongPositionUpdated(newMinLongPosition);
 

--- a/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
+++ b/src/UsdnProtocol/libraries/UsdnProtocolSettersLibrary.sol
@@ -230,10 +230,10 @@ library UsdnProtocolSettersLibrary {
     }
 
     /// @notice See {UsdnProtocolFallback.setSdexBurnOnDepositRatio}.
-    function setSdexBurnOnDepositRatio(uint32 newRatio) external {
+    function setSdexBurnOnDepositRatio(uint256 highestPossibleValue, uint32 newRatio) external {
         Types.Storage storage s = Utils._getMainStorage();
 
-        if (newRatio > Constants.MAX_SDEX_BURN_RATIO) {
+        if (newRatio > highestPossibleValue) {
             revert IUsdnProtocolErrors.UsdnProtocolInvalidBurnSdexOnDepositRatio();
         }
 
@@ -313,8 +313,12 @@ library UsdnProtocolSettersLibrary {
     }
 
     /// @notice See {UsdnProtocolFallback.setMinLongPosition}.
-    function setMinLongPosition(uint256 newMinLongPosition) external {
+    function setMinLongPosition(uint256 highestPossibleValue, uint256 newMinLongPosition) external {
         Types.Storage storage s = Utils._getMainStorage();
+
+        if (newMinLongPosition > highestPossibleValue) {
+            revert IUsdnProtocolErrors.UsdnProtocolInvalidMinLongPosition();
+        }
 
         s._minLongPosition = newMinLongPosition;
         emit IUsdnProtocolEvents.MinLongPositionUpdated(newMinLongPosition);

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolFallback.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolFallback.sol
@@ -586,6 +586,9 @@ interface IUsdnProtocolFallback is IUsdnProtocolTypes {
     /**
      * @notice Sets the minimum long position size.
      * @dev This value is used to prevent users from opening positions that are too small and not worth liquidating.
+     * As this parameter highly depends on the value of the underlying asset, the max value for `newMinLongPosition` is
+     * given as a constructor argument when the {UsdnProtocolFallback} contract is deployed, and is stored in an
+     * immutable variable.
      * @param newMinLongPosition The new minimum long position size (with `_assetDecimals`).
      */
     function setMinLongPosition(uint256 newMinLongPosition) external;
@@ -653,6 +656,8 @@ interface IUsdnProtocolFallback is IUsdnProtocolTypes {
 
     /**
      * @notice Sets the ratio of SDEX tokens to burn per minted USDN.
+     * @dev As this parameter highly depends on the value of the USDN token, the max value for `newRatio` is given as a
+     * constructor argument when the {UsdnProtocolFallback} contract is deployed and is stored in an immutable variable.
      * @param newRatio The new ratio.
      */
     function setSdexBurnOnDepositRatio(uint32 newRatio) external;

--- a/src/interfaces/UsdnProtocol/IUsdnProtocolImpl.sol
+++ b/src/interfaces/UsdnProtocol/IUsdnProtocolImpl.sol
@@ -4,11 +4,7 @@ pragma solidity >=0.8.0;
 import { IAccessControlDefaultAdminRules } from
     "@openzeppelin/contracts/access/extensions/IAccessControlDefaultAdminRules.sol";
 import { IERC5267 } from "@openzeppelin/contracts/interfaces/IERC5267.sol";
-import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { IBaseLiquidationRewardsManager } from "../LiquidationRewardsManager/IBaseLiquidationRewardsManager.sol";
-import { IBaseOracleMiddleware } from "../OracleMiddleware/IBaseOracleMiddleware.sol";
-import { IUsdn } from "../Usdn/IUsdn.sol";
 import { IUsdnProtocolActions } from "./IUsdnProtocolActions.sol";
 import { IUsdnProtocolCore } from "./IUsdnProtocolCore.sol";
 import { IUsdnProtocolFallback } from "./IUsdnProtocolFallback.sol";

--- a/test/integration/UsdnProtocol/utils/Fixtures.sol
+++ b/test/integration/UsdnProtocol/utils/Fixtures.sol
@@ -53,9 +53,6 @@ contract UsdnProtocolBaseIntegrationFixture is
     IEventsErrors,
     DefaultConfig
 {
-    uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
-    uint256 constant MAX_MIN_LONG_POSITION = 10 ether;
-
     struct SetUpParams {
         uint128 initialDeposit;
         uint128 initialLong;

--- a/test/integration/UsdnProtocol/utils/Fixtures.sol
+++ b/test/integration/UsdnProtocol/utils/Fixtures.sol
@@ -38,8 +38,6 @@ import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthO
 import { Rebalancer } from "../../../../src/Rebalancer/Rebalancer.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
-import { UsdnProtocolConstantsLibrary as Constants } from
-    "../../../../src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol";
 import { PriceInfo } from "../../../../src/interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
 import { IUsdnProtocol } from "../../../../src/interfaces/UsdnProtocol/IUsdnProtocol.sol";
 import { IUsdnProtocolErrors } from "../../../../src/interfaces/UsdnProtocol/IUsdnProtocolErrors.sol";

--- a/test/integration/UsdnProtocol/utils/Fixtures.sol
+++ b/test/integration/UsdnProtocol/utils/Fixtures.sol
@@ -38,6 +38,8 @@ import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthO
 import { Rebalancer } from "../../../../src/Rebalancer/Rebalancer.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
+import { UsdnProtocolConstantsLibrary as Constants } from
+    "../../../../src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol";
 import { PriceInfo } from "../../../../src/interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
 import { IUsdnProtocol } from "../../../../src/interfaces/UsdnProtocol/IUsdnProtocol.sol";
 import { IUsdnProtocolErrors } from "../../../../src/interfaces/UsdnProtocol/IUsdnProtocolErrors.sol";
@@ -51,6 +53,9 @@ contract UsdnProtocolBaseIntegrationFixture is
     IEventsErrors,
     DefaultConfig
 {
+    uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
+    uint256 constant MAX_MIN_LONG_POSITION = 10 ether;
+
     struct SetUpParams {
         uint128 initialDeposit;
         uint128 initialLong;
@@ -171,8 +176,8 @@ contract UsdnProtocolBaseIntegrationFixture is
         require(success, "DEPLOYER wstETH mint failed");
         usdn = new Usdn(address(0), address(0));
 
-        implementation = new UsdnProtocolHandler();
-        protocolFallback = new UsdnProtocolFallback();
+        implementation = new UsdnProtocolHandler(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
+        protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
 
         _setPeripheralContracts(
             oracleMiddleware, liquidationRewardsManager, usdn, wstETH, address(protocolFallback), ADMIN, sdex

--- a/test/unit/Rebalancer/utils/Fixtures.sol
+++ b/test/unit/Rebalancer/utils/Fixtures.sol
@@ -54,7 +54,8 @@ contract RebalancerFixture is
         oracleMiddleware = new MockOracleMiddleware();
         liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wstETH);
 
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(1e8, 10 ether);
+        UsdnProtocolFallback protocolFallback =
+            new UsdnProtocolFallback(DefaultConfig.MAX_SDEX_BURN_RATIO, DefaultConfig.MAX_MIN_LONG_POSITION);
         UsdnProtocolImpl implementation = new UsdnProtocolImpl();
 
         _setPeripheralContracts(

--- a/test/unit/Rebalancer/utils/Fixtures.sol
+++ b/test/unit/Rebalancer/utils/Fixtures.sol
@@ -54,7 +54,7 @@ contract RebalancerFixture is
         oracleMiddleware = new MockOracleMiddleware();
         liquidationRewardsManager = new LiquidationRewardsManagerWstEth(wstETH);
 
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback();
+        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(1e8, 10 ether);
         UsdnProtocolImpl implementation = new UsdnProtocolImpl();
 
         _setPeripheralContracts(

--- a/test/unit/UsdnProtocol/Admin.t.sol
+++ b/test/unit/UsdnProtocol/Admin.t.sol
@@ -484,7 +484,7 @@ contract TestUsdnProtocolAdmin is UsdnProtocolBaseFixture, IRebalancerEvents {
      * @custom:then The call reverts
      */
     function test_RevertWhen_setSdexBurnOnDepositRatioWithMax() public adminPrank {
-        uint32 aboveMax = uint32(Constants.MAX_SDEX_BURN_RATIO + 1);
+        uint32 aboveMax = uint32(MAX_SDEX_BURN_RATIO + 1);
 
         vm.expectRevert(UsdnProtocolInvalidBurnSdexOnDepositRatio.selector);
         protocol.setSdexBurnOnDepositRatio(aboveMax);
@@ -945,6 +945,17 @@ contract TestUsdnProtocolAdmin is UsdnProtocolBaseFixture, IRebalancerEvents {
         // assert that the new values are equal to the expected values
         assertEq(protocol.getMinLongPosition(), newValue, "protocol value isn't updated");
         assertEq(rebalancer.getMinAssetDeposit(), newValue, "rebalancer value isn't updated");
+    }
+
+    /**
+     * @custom:scenario Call "setMinLongPosition" from admin
+     * @custom:given The initial usdnProtocol state
+     * @custom:when Admin wallet triggers the function with a value above the limit
+     * @custom:then The transaction should revert with the corresponding error
+     */
+    function test_RevertWhen_invalidSetMinLongPosition() public adminPrank {
+        vm.expectRevert(UsdnProtocolInvalidMinLongPosition.selector);
+        protocol.setMinLongPosition(MAX_MIN_LONG_POSITION + 1);
     }
 
     /**

--- a/test/unit/UsdnProtocol/Admin.t.sol
+++ b/test/unit/UsdnProtocol/Admin.t.sol
@@ -948,17 +948,6 @@ contract TestUsdnProtocolAdmin is UsdnProtocolBaseFixture, IRebalancerEvents {
     }
 
     /**
-     * @custom:scenario Call "setMinLongPosition" from admin
-     * @custom:given The initial usdnProtocol state
-     * @custom:when Admin wallet triggers the function with a value above the limit
-     * @custom:then The transaction should revert with the corresponding error
-     */
-    function test_RevertWhen_invalidSetMinLongPosition() public adminPrank {
-        vm.expectRevert(UsdnProtocolInvalidMinLongPosition.selector);
-        protocol.setMinLongPosition(10 ether + 1);
-    }
-
-    /**
      * @custom:scenario Call `setPositionFeeBps` as admin
      * @custom:when The admin sets the position fee between 0 and 2000 bps
      * @custom:then The position fee should be updated

--- a/test/unit/UsdnProtocol/Initialize.t.sol
+++ b/test/unit/UsdnProtocol/Initialize.t.sol
@@ -11,7 +11,6 @@ import { UsdnProtocolHandler } from "./utils/Handler.sol";
 
 import { WstEthOracleMiddleware } from "../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Usdn } from "../../../src/Usdn/Usdn.sol";
-import { UsdnProtocolFallback } from "../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
 import { UsdnProtocolConstantsLibrary as Constants } from
     "../../../src/UsdnProtocol/libraries/UsdnProtocolConstantsLibrary.sol";
 import { IUsdnProtocol } from "../../../src/interfaces/UsdnProtocol/IUsdnProtocol.sol";
@@ -30,7 +29,6 @@ contract TestUsdnProtocolInitialize is UsdnProtocolBaseFixture {
         vm.startPrank(ADMIN);
         usdn = new Usdn(address(0), address(0));
 
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
         UsdnProtocolHandler test = new UsdnProtocolHandler(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
 
         _setPeripheralContracts(
@@ -38,7 +36,7 @@ contract TestUsdnProtocolInitialize is UsdnProtocolBaseFixture {
             liquidationRewardsManager,
             usdn,
             wstETH,
-            address(protocolFallback),
+            address(0),
             ADMIN,
             sdex
         );

--- a/test/unit/UsdnProtocol/Initialize.t.sol
+++ b/test/unit/UsdnProtocol/Initialize.t.sol
@@ -30,8 +30,8 @@ contract TestUsdnProtocolInitialize is UsdnProtocolBaseFixture {
         vm.startPrank(ADMIN);
         usdn = new Usdn(address(0), address(0));
 
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback();
-        UsdnProtocolHandler test = new UsdnProtocolHandler();
+        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
+        UsdnProtocolHandler test = new UsdnProtocolHandler(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
 
         _setPeripheralContracts(
             WstEthOracleMiddleware(address(oracleMiddleware)),

--- a/test/unit/UsdnProtocol/Proxy/Proxy.t.sol
+++ b/test/unit/UsdnProtocol/Proxy/Proxy.t.sol
@@ -108,7 +108,7 @@ contract TestUsdnProtocolProxy is UsdnProtocolBaseFixture {
         _storageSnapshot();
 
         vm.startPrank(ADMIN);
-        UsdnProtocolFallback newProtocolFallback = new UsdnProtocolFallback();
+        UsdnProtocolFallback newProtocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
         UsdnProtocolImplV2 newImplementation = new UsdnProtocolImplV2();
 
         vm.expectEmit();

--- a/test/unit/UsdnProtocol/Storage/Constructor.t.sol
+++ b/test/unit/UsdnProtocol/Storage/Constructor.t.sol
@@ -27,7 +27,7 @@ contract TestUsdnProtocolStorageConstructor is UsdnProtocolBaseFixture {
     function setUp() public {
         _setUp(DEFAULT_PARAMS);
         implementation = new UsdnProtocolImpl();
-        protocolFallback = new UsdnProtocolFallback();
+        protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
     }
 
     /**

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -19,7 +19,6 @@ import { LiquidationRewardsManagerWstEth } from
     "../../../../src/LiquidationRewardsManager/LiquidationRewardsManagerWstEth.sol";
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
-import { UsdnProtocolFallback } from "../../../../src/UsdnProtocol/UsdnProtocolFallback.sol";
 import { UsdnProtocolActionsUtilsLibrary as ActionUtils } from
     "../../../../src/UsdnProtocol/libraries/UsdnProtocolActionsUtilsLibrary.sol";
 import { UsdnProtocolConstantsLibrary as Constants } from
@@ -146,20 +145,19 @@ contract UsdnProtocolBaseFixture is
         }
 
         UsdnProtocolHandler test = new UsdnProtocolHandler(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
 
         _setPeripheralContracts(
             WstEthOracleMiddleware(address(oracleMiddleware)),
             liquidationRewardsManager,
             usdn,
             wstETH,
-            address(protocolFallback),
+            address(0),
             address(feeCollector),
             sdex
         );
 
         address proxy = UnsafeUpgrades.deployUUPSProxy(
-            address(test), abi.encodeCall(UsdnProtocolHandler.initializeStorageHandler, (initStorage))
+            address(test), abi.encodeCall(UsdnProtocolHandler.initializeStorageHandler, initStorage)
         );
         protocol = UsdnProtocolHandler(proxy);
 

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -43,6 +43,9 @@ contract UsdnProtocolBaseFixture is
     IUsdnProtocolEvents,
     DefaultConfig
 {
+    uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
+    uint256 constant MAX_MIN_LONG_POSITION = 10 ether;
+
     struct Flags {
         bool enablePositionFees;
         bool enableProtocolFees;
@@ -145,8 +148,8 @@ contract UsdnProtocolBaseFixture is
             });
         }
 
-        UsdnProtocolHandler test = new UsdnProtocolHandler();
-        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback();
+        UsdnProtocolHandler test = new UsdnProtocolHandler(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
+        UsdnProtocolFallback protocolFallback = new UsdnProtocolFallback(MAX_SDEX_BURN_RATIO, MAX_MIN_LONG_POSITION);
 
         _setPeripheralContracts(
             WstEthOracleMiddleware(address(oracleMiddleware)),

--- a/test/unit/UsdnProtocol/utils/Fixtures.sol
+++ b/test/unit/UsdnProtocol/utils/Fixtures.sol
@@ -43,9 +43,6 @@ contract UsdnProtocolBaseFixture is
     IUsdnProtocolEvents,
     DefaultConfig
 {
-    uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
-    uint256 constant MAX_MIN_LONG_POSITION = 10 ether;
-
     struct Flags {
         bool enablePositionFees;
         bool enableProtocolFees;

--- a/test/unit/UsdnProtocol/utils/Handler.sol
+++ b/test/unit/UsdnProtocol/utils/Handler.sol
@@ -39,6 +39,10 @@ contract UsdnProtocolHandler is UsdnProtocolImpl, UsdnProtocolFallback, Test {
     using SafeCast for uint256;
     using SignedMath for int256;
 
+    constructor(uint256 maxSdexBurnRatio, uint256 maxMinLongPosition)
+        UsdnProtocolFallback(maxSdexBurnRatio, maxMinLongPosition)
+    { }
+
     function initializeStorageHandler(InitStorage calldata initStorage) external initializer {
         initializeStorage(initStorage);
     }

--- a/test/utils/DefaultConfig.sol
+++ b/test/utils/DefaultConfig.sol
@@ -12,6 +12,9 @@ import { IWstETH } from "../../src/interfaces/IWstETH.sol";
 import { IUsdnProtocolTypes as Types } from "../../src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
 
 contract DefaultConfig {
+    uint256 constant MAX_SDEX_BURN_RATIO = Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR / 10; // 10%
+    uint256 constant MAX_MIN_LONG_POSITION = 10 ether;
+
     Types.InitStorage internal initStorage;
 
     constructor() {


### PR DESCRIPTION
As those values are highly dependent on the monetary value of the underlying token or the attached USDN token, having them as constants do not make sense. They are now decided by the deployer using the `DeploymentConfig` files and given to the `UsdnProtocolFallback` contract as constructor arguments on deployment. 

BREAKING CHANGE: The UsdnProtocolFallback contract now requires 2 parameters to be deployed

Contributes to RA2BL-627