### PR TITLE
feat(middleware): add shortDN middleware using Chainlink Data Streams

### DIFF
--- a/script/01_DeployUsdnWusdnEth.s.sol
+++ b/script/01_DeployUsdnWusdnEth.s.sol
@@ -11,7 +11,7 @@ import { UsdnWusdnEthConfig } from "./deploymentConfigs/UsdnWusdnEthConfig.sol";
 import { Utils } from "./utils/Utils.s.sol";
 
 import { LiquidationRewardsManagerWusdn } from "../src/LiquidationRewardsManager/LiquidationRewardsManagerWusdn.sol";
-import { WusdnToEthOracleMiddleware } from "../src/OracleMiddleware/WusdnToEthOracleMiddleware.sol";
+import { WusdnToEthOracleMiddlewareWithPyth } from "../src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol";
 import { Rebalancer } from "../src/Rebalancer/Rebalancer.sol";
 import { UsdnNoRebase } from "../src/Usdn/UsdnNoRebase.sol";
 import { UsdnProtocolFallback } from "../src/UsdnProtocol/UsdnProtocolFallback.sol";
@@ -42,7 +42,7 @@ contract DeployUsdnWusdnEth is UsdnWusdnEthConfig, Script {
     function run()
         external
         returns (
-            WusdnToEthOracleMiddleware wusdnToEthOracleMiddleware_,
+            WusdnToEthOracleMiddlewareWithPyth wusdnToEthOracleMiddleware_,
             LiquidationRewardsManagerWusdn liquidationRewardsManagerWusdn_,
             Rebalancer rebalancer_,
             UsdnNoRebase usdnNoRebase_,
@@ -79,14 +79,14 @@ contract DeployUsdnWusdnEth is UsdnWusdnEthConfig, Script {
     function _deployAndSetPeripheralContracts()
         internal
         returns (
-            WusdnToEthOracleMiddleware wusdnToEthOracleMiddleware_,
+            WusdnToEthOracleMiddlewareWithPyth wusdnToEthOracleMiddleware_,
             LiquidationRewardsManagerWusdn liquidationRewardsManagerWusdn_,
             UsdnNoRebase usdnNoRebase_
         )
     {
         vm.startBroadcast();
         liquidationRewardsManagerWusdn_ = new LiquidationRewardsManagerWusdn(WUSDN);
-        wusdnToEthOracleMiddleware_ = new WusdnToEthOracleMiddleware(
+        wusdnToEthOracleMiddleware_ = new WusdnToEthOracleMiddlewareWithPyth(
             PYTH_ADDRESS, PYTH_ETH_FEED_ID, CHAINLINK_ETH_PRICE, address(WUSDN.USDN()), CHAINLINK_PRICE_VALIDITY
         );
 
@@ -139,9 +139,10 @@ contract DeployUsdnWusdnEth is UsdnWusdnEthConfig, Script {
      * @param usdnProtocol The USDN protocol.
      * @param wusdnToEthOracleMiddleware The WstETH oracle middleware.
      */
-    function _initializeProtocol(IUsdnProtocol usdnProtocol, WusdnToEthOracleMiddleware wusdnToEthOracleMiddleware)
-        internal
-    {
+    function _initializeProtocol(
+        IUsdnProtocol usdnProtocol,
+        WusdnToEthOracleMiddlewareWithPyth wusdnToEthOracleMiddleware
+    ) internal {
         uint24 liquidationPenalty = usdnProtocol.getLiquidationPenalty();
         int24 tickSpacing = usdnProtocol.getTickSpacing();
         uint256 price = wusdnToEthOracleMiddleware.parseAndValidatePrice(

--- a/src/OracleMiddleware/OracleMiddlewareWithDataStreams.sol
+++ b/src/OracleMiddleware/OracleMiddlewareWithDataStreams.sol
@@ -12,8 +12,7 @@ import {
     PriceAdjustment,
     PriceInfo
 } from "../interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
-import { IOracleMiddlewareWithChainlinkDataStreams } from
-    "../interfaces/OracleMiddleware/IOracleMiddlewareWithChainlinkDataStreams.sol";
+import { IOracleMiddlewareWithDataStreams } from "../interfaces/OracleMiddleware/IOracleMiddlewareWithDataStreams.sol";
 import { IVerifierProxy } from "../interfaces/OracleMiddleware/IVerifierProxy.sol";
 import { IUsdnProtocol } from "../interfaces/UsdnProtocol/IUsdnProtocol.sol";
 import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
@@ -25,10 +24,10 @@ import { ChainlinkDataStreamsOracle } from "./oracles/ChainlinkDataStreamsOracle
  * @notice This contract is used to get the price of an asset from different oracles.
  * It is used by the USDN protocol to get the price of the USDN underlying asset.
  */
-contract OracleMiddlewareWithChainlinkDataStreams is
+contract OracleMiddlewareWithDataStreams is
     CommonOracleMiddleware,
     ChainlinkDataStreamsOracle,
-    IOracleMiddlewareWithChainlinkDataStreams
+    IOracleMiddlewareWithDataStreams
 {
     /**
      * @param pythContract Address of the Pyth contract.
@@ -81,7 +80,7 @@ contract OracleMiddlewareWithChainlinkDataStreams is
     /*                            Privileged functions                            */
     /* -------------------------------------------------------------------------- */
 
-    /// @inheritdoc IOracleMiddlewareWithChainlinkDataStreams
+    /// @inheritdoc IOracleMiddlewareWithDataStreams
     function setDataStreamsRecentPriceDelay(uint64 newDelay) external onlyRole(ADMIN_ROLE) {
         if (newDelay < 10 seconds) {
             revert OracleMiddlewareInvalidRecentPriceDelay(newDelay);

--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithDataStreams.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithDataStreams.sol
@@ -14,7 +14,7 @@ import { CommonOracleMiddleware, OracleMiddlewareWithDataStreams } from "./Oracl
  * @dev This version uses Pyth or Chainlink Data Streams for liquidations, and only Chainlink Data Streams for
  * validation actions.
  */
-contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithDataStreams {
+contract WusdnToEthOracleMiddlewareWithDataStreams is OracleMiddlewareWithDataStreams {
     /// @dev One dollar with the middleware decimals.
     uint256 internal constant ONE_DOLLAR = 10 ** MIDDLEWARE_DECIMALS;
 

--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithDataStreams.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithDataStreams.sol
@@ -5,15 +5,16 @@ import { IBaseOracleMiddleware } from "../interfaces/OracleMiddleware/IBaseOracl
 import { PriceInfo } from "../interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
 import { IUsdn } from "../interfaces/Usdn/IUsdn.sol";
 import { IUsdnProtocolTypes as Types } from "../interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
-import { CommonOracleMiddleware, OracleMiddlewareWithPyth } from "./OracleMiddlewareWithPyth.sol";
+import { CommonOracleMiddleware, OracleMiddlewareWithDataStreams } from "./OracleMiddlewareWithDataStreams.sol";
 
 /**
  * @title Middleware Implementation For Short ETH Protocol
  * @notice This contract is used to get the "inverse" price in ETH/WUSDN denomination, so that it can be used for a
  * shorting version of the USDN protocol with WUSDN as the underlying asset.
- * @dev This version uses Pyth for low-latency prices used during validation actions and liquidations.
+ * @dev This version uses Pyth or Chainlink Data Streams for liquidations, and only Chainlink Data Streams for
+ * validation actions.
  */
-contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithPyth {
+contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithDataStreams {
     /// @dev One dollar with the middleware decimals.
     uint256 internal constant ONE_DOLLAR = 10 ** MIDDLEWARE_DECIMALS;
 
@@ -32,14 +33,27 @@ contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithPyth {
      * @param chainlinkPriceFeed The address of the ETH Chainlink price feed.
      * @param usdnToken The address of the USDN token.
      * @param chainlinkTimeElapsedLimit The duration after which a Chainlink price is considered stale.
+     * @param chainlinkProxyVerifierAddress The address of the Chainlink proxy verifier contract.
+     * @param chainlinkStreamId The Chainlink data stream ID for ETH/USD.
      */
     constructor(
         address pythContract,
         bytes32 pythPriceID,
         address chainlinkPriceFeed,
         address usdnToken,
-        uint256 chainlinkTimeElapsedLimit
-    ) OracleMiddlewareWithPyth(pythContract, pythPriceID, chainlinkPriceFeed, chainlinkTimeElapsedLimit) {
+        uint256 chainlinkTimeElapsedLimit,
+        address chainlinkProxyVerifierAddress,
+        bytes32 chainlinkStreamId
+    )
+        OracleMiddlewareWithDataStreams(
+            pythContract,
+            pythPriceID,
+            chainlinkPriceFeed,
+            chainlinkTimeElapsedLimit,
+            chainlinkProxyVerifierAddress,
+            chainlinkStreamId
+        )
+    {
         USDN = IUsdn(usdnToken);
     }
 

--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
@@ -12,14 +12,14 @@ import { CommonOracleMiddleware, OracleMiddlewareWithPyth } from "./OracleMiddle
  * @notice This contract is used to get the "inverse" price in ETH/WUSDN denomination, so that it can be used for a
  * shorting version of the USDN protocol with WUSDN as the underlying asset.
  */
-contract WusdnToEthOracleMiddleware is OracleMiddlewareWithPyth {
+contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithPyth {
     /// @dev One dollar with the middleware decimals.
     uint256 internal constant ONE_DOLLAR = 10 ** MIDDLEWARE_DECIMALS;
 
     /// @dev Max divisor from the USDN token (as constant for gas optimisation).
     uint256 internal constant USDN_MAX_DIVISOR = 1e18;
 
-    /// @dev Numerator for the price calculation in {WusdnToEthOracleMiddleware.parseAndValidatePrice}.
+    /// @dev Numerator for the price calculation in {WusdnToEthOracleMiddlewareWithPyth.parseAndValidatePrice}.
     uint256 internal constant PRICE_NUMERATOR = 10 ** MIDDLEWARE_DECIMALS * ONE_DOLLAR * USDN_MAX_DIVISOR;
 
     /// @notice The USDN token address.

--- a/src/OracleMiddleware/oracles/ChainlinkDataStreamsOracle.sol
+++ b/src/OracleMiddleware/oracles/ChainlinkDataStreamsOracle.sol
@@ -10,7 +10,7 @@ import { IVerifierProxy } from "../../interfaces/OracleMiddleware/IVerifierProxy
 /**
  * @title Oracle Middleware for Chainlink Data Streams
  * @notice This contract is used to get the price of the asset that corresponds to the stored Chainlink data streams ID.
- * @dev Is implemented by the {OracleMiddlewareWithChainlinkDataStreams} contract.
+ * @dev Is implemented by the {OracleMiddlewareWithDataStreams} contract.
  */
 abstract contract ChainlinkDataStreamsOracle is IOracleMiddlewareErrors, IChainlinkDataStreamsOracle {
     /// @notice The address of the Chainlink proxy verifier contract.

--- a/src/interfaces/OracleMiddleware/IOracleMiddlewareWithDataStreams.sol
+++ b/src/interfaces/OracleMiddleware/IOracleMiddlewareWithDataStreams.sol
@@ -11,7 +11,7 @@ import { ICommonOracleMiddleware } from "./ICommonOracleMiddleware.sol";
  * @dev This middleware uses Chainlink Data Streams and Pyth as the low-latency oracle, and Chainlink Data Feeds as
  * fallback. For liquidations, either Pyth or Data Streams can be used. For validations, only Data Streams is accepted.
  */
-interface IOracleMiddlewareWithChainlinkDataStreams is ICommonOracleMiddleware, IChainlinkDataStreamsOracle {
+interface IOracleMiddlewareWithDataStreams is ICommonOracleMiddleware, IChainlinkDataStreamsOracle {
     /* -------------------------------------------------------------------------- */
     /*                               Owner features                               */
     /* -------------------------------------------------------------------------- */

--- a/test/integration/Middlewares/ChainlinkDataStreamsOracle/ParseAndValidatePrice.t.sol
+++ b/test/integration/Middlewares/ChainlinkDataStreamsOracle/ParseAndValidatePrice.t.sol
@@ -10,8 +10,8 @@ import { CHAINLINK_DATA_STREAMS_ETH_USD, PYTH_ETH_USD } from "../../../utils/Con
 import { ChainlinkDataStreamsFixture } from "./utils/Fixtures.sol";
 
 /**
- * @custom:feature The `parseAndValidatePrice` function of the `OracleMiddlewareWithChainlinkDataStreams`.
- * @custom:background A deployed OracleMiddlewareWithChainlinkDataStreams.
+ * @custom:feature The `parseAndValidatePrice` function of the `OracleMiddlewareWithDataStreams`.
+ * @custom:background A deployed OracleMiddlewareWithDataStreams.
  */
 contract TestChainlinkDataStreamsOracleMiddlewareParseAndValidatePriceRealData is ChainlinkDataStreamsFixture {
     using Strings for uint256;

--- a/test/integration/Middlewares/ChainlinkDataStreamsOracle/utils/Fixtures.sol
+++ b/test/integration/Middlewares/ChainlinkDataStreamsOracle/utils/Fixtures.sol
@@ -16,11 +16,11 @@ import {
 import { ActionsIntegrationFixture, CommonBaseIntegrationFixture } from "../../utils/Fixtures.sol";
 import { MockFeeManager } from "./MockFeeManager.sol";
 
-import { OracleMiddlewareWithChainlinkDataStreams } from
-    "../../../../../src/OracleMiddleware/OracleMiddlewareWithChainlinkDataStreams.sol";
+import { OracleMiddlewareWithDataStreams } from
+    "../../../../../src/OracleMiddleware/OracleMiddlewareWithDataStreams.sol";
 
 contract ChainlinkDataStreamsFixture is CommonBaseIntegrationFixture, ActionsIntegrationFixture {
-    OracleMiddlewareWithChainlinkDataStreams internal oracleMiddleware;
+    OracleMiddlewareWithDataStreams internal oracleMiddleware;
 
     uint64 internal constant PERCENTAGE_SCALAR = 1e18;
 
@@ -44,7 +44,7 @@ contract ChainlinkDataStreamsFixture is CommonBaseIntegrationFixture, ActionsInt
         chainlinkOnChain = AggregatorV3Interface(CHAINLINK_ORACLE_ETH);
 
         vm.prank(DEPLOYER);
-        oracleMiddleware = new OracleMiddlewareWithChainlinkDataStreams(
+        oracleMiddleware = new OracleMiddlewareWithDataStreams(
             address(pyth),
             PYTH_ETH_USD,
             address(chainlinkOnChain),

--- a/test/unit/Middlewares/WusdnToEthOracle/ParseAndValidate.t.sol
+++ b/test/unit/Middlewares/WusdnToEthOracle/ParseAndValidate.t.sol
@@ -10,7 +10,7 @@ import { PriceInfo } from "../../../../src/interfaces/OracleMiddleware/IOracleMi
 import { IUsdnProtocolTypes as Types } from "../../../../src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
 
 /**
- * @custom:feature The `parseAndValidatePrice` function of `WusdnToEthOracleMiddleware`
+ * @custom:feature The `parseAndValidatePrice` function of `WusdnToEthOracleMiddlewareWithPyth`
  * @custom:background Given the price ETH is 2000 USD
  * @custom:and The confidence interval is 20 USD
  * @custom:and The USDN divisor is 9e17

--- a/test/unit/Middlewares/utils/Fixtures.sol
+++ b/test/unit/Middlewares/utils/Fixtures.sol
@@ -12,7 +12,8 @@ import { MockChainlinkOnChain } from "../utils/MockChainlinkOnChain.sol";
 import { MockPyth } from "../utils/MockPyth.sol";
 
 import { WstEthOracleMiddleware } from "../../../../src/OracleMiddleware/WstEthOracleMiddleware.sol";
-import { WusdnToEthOracleMiddleware } from "../../../../src/OracleMiddleware/WusdnToEthOracleMiddleware.sol";
+import { WusdnToEthOracleMiddlewareWithPyth } from
+    "../../../../src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol";
 import { Usdn } from "../../../../src/Usdn/Usdn.sol";
 import { IOracleMiddlewareErrors } from "../../../../src/interfaces/OracleMiddleware/IOracleMiddlewareErrors.sol";
 import { IOracleMiddlewareEvents } from "../../../../src/interfaces/OracleMiddleware/IOracleMiddlewareEvents.sol";
@@ -188,7 +189,7 @@ contract WstethBaseFixture is BaseFixture, ActionsFixture {
 contract WusdnToEthBaseFixture is BaseFixture, ActionsFixture {
     MockPyth internal mockPyth;
     MockChainlinkOnChain internal mockChainlinkOnChain;
-    WusdnToEthOracleMiddleware public middleware;
+    WusdnToEthOracleMiddlewareWithPyth public middleware;
     Usdn public usdn;
 
     function setUp() public virtual {
@@ -198,8 +199,9 @@ contract WusdnToEthBaseFixture is BaseFixture, ActionsFixture {
         mockChainlinkOnChain = new MockChainlinkOnChain();
         usdn = new Usdn(address(this), address(this));
         usdn.rebase(9e17);
-        middleware =
-            new WusdnToEthOracleMiddleware(address(mockPyth), 0, address(mockChainlinkOnChain), address(usdn), 1 hours);
+        middleware = new WusdnToEthOracleMiddlewareWithPyth(
+            address(mockPyth), 0, address(mockChainlinkOnChain), address(usdn), 1 hours
+        );
     }
 
     function test_setUp() public {


### PR DESCRIPTION
This PR adds a middleware similar to the existing shortDN, but supporting Data Streams as an oracle for validate and liquidate actions. Pyth is still allowed for liquidations.

Closes RA2BL-696