### PR TITLE
build(npm): add the 'typescript' dependency to fix the `exportAbi` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "BUSL-1.1",
       "dependencies": {
+        "typescript": "^5.8.2",
         "viem": "^2.18.5"
       },
       "devDependencies": {
@@ -3320,6 +3321,19 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "tsx": "^4.19.1"
   },
   "dependencies": {
+    "typescript": "^5.8.2",
     "viem": "^2.18.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "picocolors": "^1.0.1",
     "solhint": "^5.0.2",
     "tsup": "^8.3.5",
-    "tsx": "^4.19.1"
+    "tsx": "^4.19.1",
+    "typescript": "^5.8.2"
   },
   "dependencies": {
-    "typescript": "^5.8.2",
     "viem": "^2.18.5"
   }
 }


### PR DESCRIPTION
This PR aims to fix commands that required the `typescript` package to function properly, like `exportAbi`.
Natspec-smells was using it as a dependency, which is why it worked before, removing natspec-smell (eb7905a) also removed the package from our dependencies and broke the usage of the script.