### PR TITLE
refactor: relax abstract contracts version

### DIFF
--- a/script/deploymentConfigs/DeploymentConfig.sol
+++ b/script/deploymentConfigs/DeploymentConfig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 

--- a/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
+++ b/src/LiquidationRewardsManager/LiquidationRewardsManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/OracleMiddleware/CommonOracleMiddleware.sol
+++ b/src/OracleMiddleware/CommonOracleMiddleware.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { AccessControlDefaultAdminRules } from
     "@openzeppelin/contracts/access/extensions/AccessControlDefaultAdminRules.sol";

--- a/src/OracleMiddleware/oracles/ChainlinkDataStreamsOracle.sol
+++ b/src/OracleMiddleware/oracles/ChainlinkDataStreamsOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { IChainlinkDataStreamsOracle } from "../../interfaces/OracleMiddleware/IChainlinkDataStreamsOracle.sol";
 import { IFeeManager } from "../../interfaces/OracleMiddleware/IFeeManager.sol";

--- a/src/OracleMiddleware/oracles/ChainlinkOracle.sol
+++ b/src/OracleMiddleware/oracles/ChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 

--- a/src/OracleMiddleware/oracles/PythOracle.sol
+++ b/src/OracleMiddleware/oracles/PythOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { IPyth } from "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import { PythStructs } from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";

--- a/src/OracleMiddleware/oracles/RedstoneOracle.sol
+++ b/src/OracleMiddleware/oracles/RedstoneOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 // Temporary measure, forked the contracts to remove dependency on safemath
 

--- a/src/UsdnProtocol/UsdnProtocolActions.sol
+++ b/src/UsdnProtocol/UsdnProtocolActions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import { EIP712Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";

--- a/src/UsdnProtocol/UsdnProtocolCore.sol
+++ b/src/UsdnProtocol/UsdnProtocolCore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { AccessControlDefaultAdminRulesUpgradeable } from
     "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";

--- a/src/UsdnProtocol/UsdnProtocolLong.sol
+++ b/src/UsdnProtocol/UsdnProtocolLong.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { HugeUint } from "@smardex-solidity-libraries-1/HugeUint.sol";
 

--- a/src/UsdnProtocol/UsdnProtocolVault.sol
+++ b/src/UsdnProtocol/UsdnProtocolVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 import { IUsdnProtocolVault } from "../interfaces/UsdnProtocol/IUsdnProtocolVault.sol";
 import { UsdnProtocolVaultLibrary as Vault } from "./libraries/UsdnProtocolVaultLibrary.sol";

--- a/src/utils/InitializableReentrancyGuard.sol
+++ b/src/utils/InitializableReentrancyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.0;
 
 /**
  * @title Reentrancy Guard with Initializer Check

--- a/test/unit/UsdnProtocol/utils/TransferCallback.sol
+++ b/test/unit/UsdnProtocol/utils/TransferCallback.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.0;
 
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { ERC165, IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";


### PR DESCRIPTION
For compatibility purposes, all abstract contracts are now using `^0.8.0`.

Closes RA2BL-676.