### PR TITLE
feat(burn-ratio): update the shortDN burn ratio to x75

### DIFF
--- a/script/deploymentConfigs/UsdnWusdnEthConfig.sol
+++ b/script/deploymentConfigs/UsdnWusdnEthConfig.sol
@@ -51,9 +51,8 @@ contract UsdnWusdnEthConfig is DeploymentConfig {
         initStorage.positionFeeBps = 1; // 0.01%
         initStorage.vaultFeeBps = 4; // 0.04%
         initStorage.sdexRewardsRatioBps = 100; // 1%
-        // As the amount of syntETH minted will be low, we need a high ratio for the amount burned to be significant.
-        // TODO temporary (but usable) value, an improvement of the scaling of this variable is in the work
-        initStorage.sdexBurnOnDepositRatio = uint32(MAX_SDEX_BURN_RATIO);
+        // for each syntETH, 75 SDEX will be burned
+        initStorage.sdexBurnOnDepositRatio = uint64(75 * Constants.SDEX_BURN_ON_DEPOSIT_DIVISOR); // x75
         initStorage.securityDepositValue = 0.15 ether;
         initStorage.EMA = int256(3 * 10 ** (Constants.FUNDING_RATE_DECIMALS - 4)); // 0.0003
         initStorage.tickSpacing = 100;


### PR DESCRIPTION
Update the burn ratio of SDEX to 75x the number of minted syntETH.

For example, for 1 syntETH minted at $1500, the user will burn 75 SDEX. At a price of $0.004 per SDEX, it is 0.02% of the dollar value.

Closes RA2BL-759.