### PR TITLE
fix(oracle-middleware): revert when the Pyth confidence is higher than the price

### DIFF
--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithDataStreams.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithDataStreams.sol
@@ -9,7 +9,7 @@ import { CommonOracleMiddleware, OracleMiddlewareWithDataStreams } from "./Oracl
 
 /**
  * @title Middleware Implementation For Short ETH Protocol
- * @notice This contract is used to get the "inverse" price in ETH/WUSDN denomination, so that it can be used for a
+ * @notice This contract is used to get the "inverse" price in number of ETH per WUSDN, so that it can be used for a
  * shorting version of the USDN protocol with WUSDN as the underlying asset.
  * @dev This version uses Pyth or Chainlink Data Streams for liquidations, and only Chainlink Data Streams for
  * validation actions.

--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
@@ -100,6 +100,7 @@ contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithPyth {
             }
 
             if (adjustmentDelta > 0) {
+                // adjustmentDelta is strictly smaller than neutralPrice so we can safely subtract it
                 unchecked {
                     adjustedPrice = ethPrice.neutralPrice - uint256(adjustmentDelta);
                 }

--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
@@ -11,7 +11,7 @@ import { CommonOracleMiddleware, OracleMiddlewareWithPyth } from "./OracleMiddle
 
 /**
  * @title Middleware Implementation For Short ETH Protocol
- * @notice This contract is used to get the "inverse" price in ETH/WUSDN denomination, so that it can be used for a
+ * @notice This contract is used to get the "inverse" price in number of ETH per WUSDN, so that it can be used for a
  * shorting version of the USDN protocol with WUSDN as the underlying asset.
  * @dev This version uses Pyth for low-latency prices used during validation actions and liquidations.
  */

--- a/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
+++ b/src/OracleMiddleware/WusdnToEthOracleMiddlewareWithPyth.sol
@@ -97,9 +97,16 @@ contract WusdnToEthOracleMiddlewareWithPyth is OracleMiddlewareWithPyth {
             uint256 adjustedPrice;
             if (FixedPointMathLib.abs(adjustmentDelta) >= ethPrice.neutralPrice) {
                 revert OracleMiddlewareConfValueTooHigh();
-            } else {
-                adjustedPrice = uint256(int256(ethPrice.neutralPrice) - adjustmentDelta);
             }
+
+            if (adjustmentDelta > 0) {
+                unchecked {
+                    adjustedPrice = ethPrice.neutralPrice - uint256(adjustmentDelta);
+                }
+            } else {
+                adjustedPrice = ethPrice.neutralPrice + uint256(-adjustmentDelta);
+            }
+
             return PriceInfo({
                 price: PRICE_NUMERATOR / (adjustedPrice * divisor),
                 neutralPrice: PRICE_NUMERATOR / (ethPrice.neutralPrice * divisor),

--- a/src/interfaces/OracleMiddleware/IOracleMiddlewareErrors.sol
+++ b/src/interfaces/OracleMiddleware/IOracleMiddlewareErrors.sol
@@ -42,6 +42,9 @@ interface IOracleMiddlewareErrors {
      */
     error OracleMiddlewarePythPositiveExponent(int32 expo);
 
+    /// @notice Indicates that the confidence value is higher than the price.
+    error OracleMiddlewareConfValueTooHigh();
+
     /// @notice Indicates that the confidence ratio is too high.
     error OracleMiddlewareConfRatioTooHigh();
 

--- a/test/unit/Middlewares/Oracle/PythOracle.t.sol
+++ b/test/unit/Middlewares/Oracle/PythOracle.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.26;
 import { MOCK_PYTH_DATA } from "../utils/Constants.sol";
 import { OracleMiddlewareBaseFixture } from "../utils/Fixtures.sol";
 
-import { PriceInfo } from "../../../../src/interfaces/OracleMiddleware/IOracleMiddlewareTypes.sol";
 import { IUsdnProtocolTypes as Types } from "../../../../src/interfaces/UsdnProtocol/IUsdnProtocolTypes.sol";
 
 /// @custom:feature The `PythOracle` specific functions

--- a/test/unit/Middlewares/Oracle/PythOracle.t.sol
+++ b/test/unit/Middlewares/Oracle/PythOracle.t.sol
@@ -18,17 +18,18 @@ contract TestOracleMiddlewarePythOracle is OracleMiddlewareBaseFixture {
      * @custom:given The price of the asset is $10 and the confidence interval is $30.
      * @custom:when The `parseAndValidatePrice` function is called with an action that uses the lower bound of the conf
      * interval.
-     * @custom:then The price is adjusted to 1 wei to avoid being negative or zero.
+     * @custom:then The function reverts with the error {OracleMiddlewareConfValueTooHigh}.
      */
     function test_pythConfGreaterThanPrice() public {
+        uint256 validationCost = oracleMiddleware.validationCost(MOCK_PYTH_DATA, Types.ProtocolAction.ValidateDeposit);
+
         mockPyth.setPrice(10e8);
         mockPyth.setConf(30e8);
 
-        // ValidateDeposit adjusts down with conf
-        PriceInfo memory price = oracleMiddleware.parseAndValidatePrice{
-            value: oracleMiddleware.validationCost(MOCK_PYTH_DATA, Types.ProtocolAction.ValidateDeposit)
-        }("", uint128(block.timestamp), Types.ProtocolAction.ValidateDeposit, MOCK_PYTH_DATA);
-        assertEq(price.price, 1, "price should be 1");
+        vm.expectRevert(OracleMiddlewareConfValueTooHigh.selector);
+        oracleMiddleware.parseAndValidatePrice{ value: validationCost }(
+            "", uint128(block.timestamp), Types.ProtocolAction.ValidateDeposit, MOCK_PYTH_DATA
+        );
     }
 
     /**


### PR DESCRIPTION
If the adjusted confidence of Pyth is higher than the price itself, we currently set the price to 1 wei. In this situation, we now revert.

Closes RA2BL-855.