### PR TITLE
fix(deployment-script): add missing initializer in the allowed option of oz

### DIFF
--- a/script/01_DeployUsdnWstethUsd.s.sol
+++ b/script/01_DeployUsdnWstethUsd.s.sol
@@ -101,7 +101,7 @@ contract DeployUsdnWstethUsd is UsdnWstethUsdConfig, Script {
     function _deployProtocol(Types.InitStorage storage initStorage) internal returns (IUsdnProtocol usdnProtocol_) {
         // we need to allow external library linking and immutable variables in the openzeppelin module
         Options memory opts;
-        opts.unsafeAllow = "external-library-linking,state-variable-immutable";
+        opts.unsafeAllow = "external-library-linking,state-variable-immutable,missing-initializer";
 
         vm.startBroadcast();
 

--- a/script/01_DeployUsdnWusdnEth.s.sol
+++ b/script/01_DeployUsdnWusdnEth.s.sol
@@ -104,7 +104,7 @@ contract DeployUsdnWusdnEth is UsdnWusdnEthConfig, Script {
     function _deployProtocol(Types.InitStorage storage initStorage) internal returns (IUsdnProtocol usdnProtocol_) {
         // we need to allow external library linking and immutable variables in the openzeppelin module
         Options memory opts;
-        opts.unsafeAllow = "external-library-linking,state-variable-immutable";
+        opts.unsafeAllow = "external-library-linking,state-variable-immutable,missing-initializer";
 
         vm.startBroadcast();
 


### PR DESCRIPTION
The deployment script stopped working due to a new error caused by a missing initializer in `UsdnProtocolImpl`. This error has been added to the allowed list.