### PR TITLE
feat(USDNr): add ownable2Step

### DIFF
--- a/src/Usdn/Usdnr.sol
+++ b/src/Usdn/Usdnr.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
+import { Ownable, Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 import { IUsdn } from "../interfaces/Usdn/IUsdn.sol";
@@ -12,12 +13,15 @@ import { IUsdnr } from "../interfaces/Usdn/IUsdnr.sol";
  * @dev The generated yield from the underlying USDN tokens is retained within the contract, and withdrawable by the
  * owner.
  */
-contract Usdnr is ERC20, IUsdnr {
+contract Usdnr is ERC20, IUsdnr, Ownable2Step {
     /// @inheritdoc IUsdnr
     IUsdn public immutable USDN;
 
-    /// @param usdn The address of the USDN token contract.
-    constructor(IUsdn usdn) ERC20("USDN Reserve", "USDNr") {
+    /**
+     * @param usdn The address of the USDN token contract.
+     * @param owner The owner of the USDNr contract.
+     */
+    constructor(IUsdn usdn, address owner) ERC20("USDN Reserve", "USDNr") Ownable(owner) {
         USDN = usdn;
     }
 

--- a/src/interfaces/Usdn/IUsdnr.sol
+++ b/src/interfaces/Usdn/IUsdnr.sol
@@ -15,6 +15,8 @@ interface IUsdnr is IERC20Metadata {
 
     /**
      * @notice Wraps USDN into USDNr at a 1:1 ratio.
+     *  @dev When approving USDN, use the `convertToTokensRoundUp` of the user shares, as we always round up when
+     * deducting from a token transfer allowance.
      * @param usdnAmount The amount of USDN to wrap.
      */
     function wrap(uint256 usdnAmount) external;

--- a/test/unit/USDNr/Constructor.t.sol
+++ b/test/unit/USDNr/Constructor.t.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { UsdnrTokenFixture } from "./utils/Fixtures.sol";
+
+import { Usdnr } from "../../../src/Usdn/Usdnr.sol";
+
+/// @custom:feature The constructor features of `USDNr` contract
+contract TestUsdnrConstructor is UsdnrTokenFixture {
+    /**
+     * @custom:scenario The constructor sets the correct values
+     * @custom:when The contract is deployed
+     * @custom:then The name and symbol are set correctly
+     * @custom:then The USDN address is set correctly
+     * @custom:then The owner is set correctly
+     */
+    function test_usdnrConstructor() public {
+        usdnr = new Usdnr(usdn, address(this));
+
+        assertEq(usdnr.name(), "USDN Reserve", "name");
+        assertEq(usdnr.symbol(), "USDNr", "symbol");
+        assertEq(address(usdnr.USDN()), address(usdn), "USDN address");
+        assertEq(usdnr.owner(), address(this), "owner");
+    }
+
+    /**
+     * @custom:scenario Ownable2Step functionality
+     * @custom:when The contract is deployed and ownership is transferred
+     * @custom:then The owner and pending owner are set correctly
+     * @custom:then The new owner can accept ownership
+     */
+    function test_ownable2Step() public {
+        usdnr = new Usdnr(usdn, address(this));
+
+        assertEq(usdnr.owner(), address(this), "owner");
+        usdnr.transferOwnership(address(1));
+        assertEq(usdnr.pendingOwner(), address(1), "pending owner");
+        assertEq(usdnr.owner(), address(this), "owner");
+
+        vm.prank(address(1));
+        usdnr.acceptOwnership();
+        assertEq(usdnr.owner(), address(1), "owner");
+        assertEq(usdnr.pendingOwner(), address(0), "pending owner");
+    }
+}

--- a/test/unit/USDNr/utils/Fixtures.sol
+++ b/test/unit/USDNr/utils/Fixtures.sol
@@ -11,7 +11,7 @@ contract UsdnrTokenFixture is BaseFixture {
     Usdnr public usdnr;
     Usdn public usdn;
 
-    /// @dev The owner of USDNr, the minter and rebaser role of USDN are assigned to this address
+    /// @dev The owner of USDNr, the minter and the rebaser role of USDN are assigned to this address
     function setUp() public virtual {
         usdn = new Usdn(address(this), address(this));
         usdnr = new Usdnr(usdn, address(this));

--- a/test/unit/USDNr/utils/Fixtures.sol
+++ b/test/unit/USDNr/utils/Fixtures.sol
@@ -11,8 +11,9 @@ contract UsdnrTokenFixture is BaseFixture {
     Usdnr public usdnr;
     Usdn public usdn;
 
+    /// @dev The owner of USDNr, the minter and rebaser role of USDN are assigned to this address
     function setUp() public virtual {
         usdn = new Usdn(address(this), address(this));
-        usdnr = new Usdnr(usdn);
+        usdnr = new Usdnr(usdn, address(this));
     }
 }


### PR DESCRIPTION
Add the ownership of the `USDNr` contract. For security purposes, the two steps version was chosen.

Closes RA2BL-1252.