### PR TITLE
feat(USDNr): add a preview for the wrap shares function

### DIFF
--- a/src/Usdn/Usdnr.sol
+++ b/src/Usdn/Usdnr.sol
@@ -26,6 +26,11 @@ contract Usdnr is ERC20, IUsdnr, Ownable2Step {
     }
 
     /// @inheritdoc IUsdnr
+    function previewWrapShares(uint256 usdnSharesAmount) external view returns (uint256 wrappedAmount_) {
+        wrappedAmount_ = usdnSharesAmount / USDN.divisor();
+    }
+
+    /// @inheritdoc IUsdnr
     function wrap(uint256 usdnAmount) external {
         if (usdnAmount == 0) {
             revert USDNrZeroAmount();

--- a/src/interfaces/Usdn/IUsdnr.sol
+++ b/src/interfaces/Usdn/IUsdnr.sol
@@ -20,6 +20,13 @@ interface IUsdnr is IERC20Metadata {
     error USDNrNoYield();
 
     /**
+     * @notice Previews the amount of USDNr that would be received for wrapping a given amount of USDN shares.
+     * @param usdnSharesAmount The amount of USDN shares to wrap.
+     * @return wrappedAmount_ The amount of USDNr that would be received.
+     */
+    function previewWrapShares(uint256 usdnSharesAmount) external view returns (uint256 wrappedAmount_);
+
+    /**
      * @notice Wraps USDN into USDNr at a 1:1 ratio.
      *  @dev When approving USDN, use the `convertToTokensRoundUp` of the user shares, as we always round up when
      * deducting from a token transfer allowance.

--- a/test/unit/USDNr/WrapShares.t.sol
+++ b/test/unit/USDNr/WrapShares.t.sol
@@ -26,6 +26,8 @@ contract TestUsdnrWrapShares is UsdnrTokenFixture {
     function test_usdnrWrapShares() public {
         uint256 amount = 10 ether;
         uint256 sharesAmount = usdn.convertToShares(amount);
+        uint256 previewedAmount = usdnr.previewWrapShares(sharesAmount);
+
         uint256 initialUsdnrBalance = usdnr.balanceOf(address(this));
         uint256 initialUsdnrTotalSupply = usdnr.totalSupply();
         uint256 usdnContractBalance = usdn.sharesOf(address(usdnr));
@@ -35,6 +37,7 @@ contract TestUsdnrWrapShares is UsdnrTokenFixture {
         uint256 wrappedAmount = usdnr.wrapShares(sharesAmount, address(this));
 
         assertEq(wrappedAmount, amount, "wrapped USDN amount");
+        assertEq(wrappedAmount, previewedAmount, "previewed wrapped USDN amount");
 
         assertEq(usdnr.balanceOf(address(this)), initialUsdnrBalance + amount, "user USDNr balance");
         assertEq(usdnr.totalSupply(), initialUsdnrTotalSupply + amount, "total USDNr supply");
@@ -52,6 +55,7 @@ contract TestUsdnrWrapShares is UsdnrTokenFixture {
     function test_wrapSharesToAnotherAddress() public {
         uint256 amount = 10 ether;
         uint256 sharesAmount = usdn.convertToShares(amount);
+        uint256 previewedAmount = usdnr.previewWrapShares(sharesAmount);
         address recipient = address(1);
 
         uint256 initialUsdnrBalance = usdnr.balanceOf(address(this));
@@ -66,6 +70,7 @@ contract TestUsdnrWrapShares is UsdnrTokenFixture {
         uint256 wrappedAmount = usdnr.wrapShares(sharesAmount, recipient);
 
         assertEq(wrappedAmount, amount, "wrapped USDN amount");
+        assertEq(wrappedAmount, previewedAmount, "previewed wrapped USDN amount");
 
         assertEq(usdnr.balanceOf(address(this)), initialUsdnrBalance, "user USDNr balance");
         assertEq(usdnr.balanceOf(recipient), initialUsdnrRecipientBalance + amount, "recipient USDNr balance");


### PR DESCRIPTION
A `previewWrapShares` function has been added.

Closes RA2BL-1259.